### PR TITLE
Fix JSON fields just showing up as longtext fields

### DIFF
--- a/perl_lib/EPrints/MetaField/Json.pm
+++ b/perl_lib/EPrints/MetaField/Json.pm
@@ -381,9 +381,13 @@ sub generate_javascript
 
 			if( !$render_only && $self->{table_dynamic_row_count} )
 			{
-				my $add_row = $session->phrase( "lib/metafield:more_spaces" );
+				my $add_row = $session->render_button(
+					name => "_internal_${attribute_name}_morespaces",
+					value => $session->phrase( 'lib/metafield:more_spaces' ),
+					class => 'ep_form_internal_button epjs_ajax'
+				);
 				$js_string .= <<"EOJ";
-const more_rows_$attribute_name = createElement('<input value="$add_row" class="ep_form_internal_button" type="button" role="button" />');
+const more_rows_$attribute_name = createElement('$add_row');
 const outer_div_$attribute_name = $target_area.parentElement.parentElement;
 outer_div_$attribute_name.after(more_rows_$attribute_name);
 more_rows_$attribute_name.addEventListener('click', function() {


### PR DESCRIPTION
This was caused by #117 (specifically 9767fc0c) because the element is now a document fragment rather than the textarea directly (same issue as 4d5cdb3 was fixing).

In this case I noticed that `$attribute_name` matched `$basename` so we could just skip trying to get the name from the `textarea` (that is no longer so accessible) and just use `$basename`.

I've also changed the 'More input rows' button so that it will always match the one used elsewhere, as previously it would always look like the classic style button.