### PR TITLE
Fixes XML special characters being escaped in phrase attributes

### DIFF
--- a/perl_lib/EPrints/XML/EPC.pm
+++ b/perl_lib/EPrints/XML/EPC.pm
@@ -364,7 +364,6 @@ sub _process_attribute
 	my $parent = $params{parent_element};
 	my $name = $node->getAttribute( "name" );
 
-
 	if( !defined( $name ) )
 	{
 		EPrints::abort("epc:attribute requires a name attribute.")
@@ -379,7 +378,17 @@ sub _process_attribute
 		$children->appendChild( process_child_nodes( $node, %params ) );
 	}
 
-	$parent->setAttribute( $name, $children->toString );
+	# Because <epc:print> creates nodes using `make_text` which calls
+	# XML::LibXML::Document::createTextNode the result is XML encoded.
+	# Attributes aren't XML encoded so we have to XML decode here.
+	my $attributes = $children->toString;
+	$attributes =~ s/&lt;/</;
+	$attributes =~ s/&gt;/>/;
+	$attributes =~ s/&quot;/"/;
+	$attributes =~ s/&apos;/'/;
+	$attributes =~ s/&amp;/&/;
+
+	$parent->setAttribute( $name, $attributes );
 
 	return undef;
 }


### PR DESCRIPTION
This works by just un-escaping them in the attribute function because <epc:print> automatically does the escaping.

Fixes #98.

It feels like it would be neater to solve this by making `print` not escape when inside an attribute however there are a few problems with this. The first is just that we can't tell we are in an attribute, but this is solvable by adding a field to `params`.

The larger problem is that `print` doesn't do the escaping itself, this is instead handled by `LibXML::createTextNode`. The proper solution here would be to instead use `createAttribute` which doesn't do the escaping however you can't then combine these together with `appendChild` in the case where you have multiple `print` blocks combining to form one attribute.