### PR TITLE
Fix longtexts being truncated to 65535 characters

### DIFF
--- a/perl_lib/EPrints/MetaField/Keywords.pm
+++ b/perl_lib/EPrints/MetaField/Keywords.pm
@@ -55,7 +55,7 @@ sub get_property_defaults
         my %defaults = $self->SUPER::get_property_defaults;
         $defaults{match} = "EQ";
 	$defaults{input_rows} = $EPrints::MetaField::FROM_CONFIG;
-        $defaults{maxlength} = 65535;
+        $defaults{maxlength} = 2**31 - 1;
 	$defaults{sql_index} = 0;
 	$defaults{separator} = ",";
         return %defaults;

--- a/perl_lib/EPrints/MetaField/Longtext.pm
+++ b/perl_lib/EPrints/MetaField/Longtext.pm
@@ -127,7 +127,7 @@ sub get_property_defaults
 	my( $self ) = @_;
 	my %defaults = $self->SUPER::get_property_defaults;
 	$defaults{input_rows} = $EPrints::MetaField::FROM_CONFIG;
-	$defaults{maxlength} = 65535;
+	$defaults{maxlength} = 2**31 - 1;
 	$defaults{sql_index} = 0;
 
 	return %defaults;


### PR DESCRIPTION
This broke citation caches for very long citations like some authors views as they would be truncated mid-way through the HTML.

As Keywords also uses `SQL_CLOB` I decided it may as well be increased as well.