### PR TITLE
Allow script tags in search results to run when infinite scrolling

### DIFF
--- a/lib/static/javascript/auto/infinite_scroll.js
+++ b/lib/static/javascript/auto/infinite_scroll.js
@@ -171,20 +171,15 @@ function ep_initialiseInfiniteScroll(containerElement) {
 
             processing = true;
 
-            const response = await fetch(nextPageUrl)
+            const response = await fetch(nextPageUrl);
             const bodyText = await response.text();
 
-            const doc = document.implementation.createHTMLDocument();
-
-            doc.documentElement.innerHTML = bodyText;
+            const doc = document.createRange().createContextualFragment(bodyText);
 
             const newResults = doc.querySelectorAll(".ep_search_result_list .ep_search_results .ep_search_result");
 
             for (const newResult of newResults) {
-
-                newResult.remove();
-                document.importNode(newResult);
-                containerElement.querySelector(".ep_search_results .ep_paginate_list").append(newResult);
+                containerElement.querySelector(".ep_search_results .ep_paginate_list").appendChild(newResult);
             }
 
             const nextLink = doc.querySelector(".ep_search_control a.ep_next");


### PR DESCRIPTION
This showed up with `limit_names_shown` which adds some javascript to hide names when there are too many, and it would just not apply this javascript to any results past the first page.

The issue was that the new pages were being created using `innerHTML` and added to a temporary `XMLDocument`. Because of the temporary document even changing it to use `contextualFragment` didn't fix it however we don't actually need a secondary document because we can pull parts out of a document fragment just fine.

I thought I had caught all the `innerHTML` bugs with #105 but clearly not.