### PR TITLE
Fix non-existent function error when running generate_static

### DIFF
--- a/bin/generate_static
+++ b/bin/generate_static
@@ -202,13 +202,6 @@ foreach my $langid ( @{$session->config( "languages" )} )
 	my $fn;
 
 	# do the magic auto.js and auto.css
-	$fn = EPrints::Update::Static::update_secure_auto_js(
-			$session,
-			$base_target_dir,
-			\@static_dirs
-		);
-	$wrote_files->{$fn} = 1;
-
 	$fn = EPrints::Update::Static::update_auto_js(
 			$session,
 			$base_target_dir,


### PR DESCRIPTION
This was caused by 4f6b8f1b removing the `update_secure_auto_js` function but not removing the call to it in `generate_static`.