### PR TITLE
Prevent an undef equality warning in epadmin create

### DIFF
--- a/bin/epadmin
+++ b/bin/epadmin
@@ -1269,7 +1269,7 @@ sub create_db
 	}
 
 	# Handles YAML::Tiny not parsing null as an undefined value
-	if( $dbaconf->{password} eq 'null' )
+	if( defined $dbaconf->{password} && $dbaconf->{password} eq 'null' )
 	{
 		$dbaconf->{password} = undef;
 	}


### PR DESCRIPTION
This check was added in #110 (249008f) however when we use `epadmin create` it doesn't necessarily set `$dbaconf->{password}` so if you go through it clicking enter where possible this will raise a warning due to string comparison on `undef`.