### PR TITLE
Prevent epadmin erroring out if you enter the wrong password

### DIFF
--- a/bin/epadmin
+++ b/bin/epadmin
@@ -1284,7 +1284,11 @@ sub create_db
 	if( !$database->create( $username, $password ) )
 	{
 		print STDERR "Error creating database: [$DBI::err] $DBI::errstr\n";
-		goto BADPASSWORD if $DBI::err == 1045;
+		# 1045 (ER_ACCESS_DENIED_ERROR) is generally raised when the username
+		# or password were wrong however if the username is correct and the
+		# password has been left empty ('') when required the error is instead
+		# 1698 (ER_ACCESS_DENIED_NO_PASSWORD_ERROR).
+		goto BADPASSWORD if $DBI::err == 1045 || $DBI::err == 1698;
 		exit 1;
 	}
 


### PR DESCRIPTION
Fixes #130. This isn't particularly about the wrong username or password but instead is that the default of 'root', '' causes a different error code because 'root' is a user that expects a password and '' counts as no password.