### PR TITLE
Prevented spurious 'archive not specified' warning when using 'epadmin --help'

### DIFF
--- a/bin/epadmin
+++ b/bin/epadmin
@@ -281,9 +281,9 @@ BEGIN
 
 	if ( scalar @ARGV )
 	{
-		if ( grep { $ARGV[0] eq $_ } qw/ create profile test / )
+		if ( grep { $ARGV[0] eq $_ } qw/ create profile test / or scalar @ARGV == 1 )
 		{
-			$ENV{IGNORE_UNKNOWN_ARCHIVE} = 1 if grep { $ARGV[0] eq $_ } qw/ create profile test /;
+			$ENV{IGNORE_UNKNOWN_ARCHIVE} = 1;
 		}
 		else
 		{


### PR DESCRIPTION
This also prevents it for some other cases like `epadmin --man` and typos in a single word command like `epadmin creatae`.

This does not however prevent all cases of these issues popping up, for example `epadmin update exmaple` or `epadmin update --dryrun` will still raise the warning.