### PR TITLE
Correctly fill the 'contributions' field from PDF imports

### DIFF
--- a/perl_lib/EPrints/Plugin/Import/PDF.pm
+++ b/perl_lib/EPrints/Plugin/Import/PDF.pm
@@ -187,18 +187,18 @@ sub parse_author
 
 	my @parsed;
 	foreach my $author (split(/,|&| and |\t|;/, $authors)) {
+		my @words = split(' ', $author);
+		my $given = join(' ', @words[0..$#words-1]);
+
 		if( $has_contributions ) {
 			push @parsed, {
 				type => $plugin->{repository}->config('entities', 'field_contribution_types', 'eprint', 'person', 'creators'),
 				contributor => {
 					datasetid => 'person',
-					name => $author,
+					name => $words[-1] . ', ' . $given,
 				}
 			}
 		} else {
-			my @words = split(' ', $author);
-			my $given = join(' ', @words[0..$#words-1]);
-
 			push @parsed, {
 				name => {
 					given => $given,


### PR DESCRIPTION
Because contributors will only autofill from `creators` to `contributors` if `contributors` doesn't exist in the workflow we have to make sure we fill the correct side depending on the workflow. The same also goes for `publisher` although this is slightly easier to fill as there is only one of them.

Fixes #138.