### PR TITLE
Replace various .pngs with their .svg equivalents

### DIFF
--- a/cgi/users/ajax/subject_input
+++ b/cgi/users/ajax/subject_input
@@ -81,7 +81,7 @@ EPJS_blur(event);
 EPJS_toggle_type('${id}_hide',false,'inline');
 EPJS_toggle_type('${id}_show',true,'inline');
 EPJS_toggleSlide('${id}_kids',false,'block'); ">
-<img alt="-" src="/style/images/minus.png" border="0" /> $label $add
+<img alt="-" src="/style/images/minus.svg" border="0" /> $label $add
 </span>
 
 <span id='${id}_show' onclick="
@@ -101,7 +101,7 @@ new Ajax.Request(
 		EPJS_toggleSlideScroll('${id}_kids',false,'${id}_toggle');
 	} 
 });"> 
-<img alt="+" src="/style/images/plus.png" border="0" /> $label
+<img alt="+" src="/style/images/plus.svg" border="0" /> $label
 </span>
 </span>
 

--- a/ingredients/eprints_classic_style/lang/en/phrases/z_system.xml
+++ b/ingredients/eprints_classic_style/lang/en/phrases/z_system.xml
@@ -2,9 +2,11 @@
 <!DOCTYPE phrases SYSTEM "entities.dtd">
 <epp:phrases xmlns="http://www.w3.org/1999/xhtml" xmlns:epp="http://eprints.org/ep3/phrase" xmlns:epc="http://eprints.org/ep3/control">
   <epp:phrase id="lib/searchexpression:results_only"><epc:pin name="n"/> results</epp:phrase>
+  <epp:phrase id="sys:ep_form_required"><img src="{$config{rel_path}}/style/images/required.png" border="0" class="ep_required" alt="Required" style="display: inline"/>&nbsp;<epc:pin name="label"/></epp:phrase>
   <epp:phrase id="sys:ep_form_required_src">/style/images/required.png</epp:phrase>
   <epp:phrase id="lib/session:hide_help_src">/style/images/minus.png</epp:phrase>
   <epp:phrase id="lib/session:show_help_src">/style/images/help.png</epp:phrase>
   <epp:phrase id="Plugin/InputForm/Surround/Default:show_help"><epc:pin name="link"><img alt="+" title="Show help" src="{$config{rel_path}}/style/images/help.png" border="0"/></epc:pin></epp:phrase>
   <epp:phrase id="Plugin/InputForm/Surround/Default:hide_help"><epc:pin name="link"><img alt="-" title="Hide help" src="{$config{rel_path}}/style/images/minus.png" border="0"/></epc:pin></epp:phrase>
+  <epp:phrase id="Update/Views:up_a_level_src">/style/images/multi_up.png</epp:phrase>
 </epp:phrases>

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -1859,7 +1859,7 @@ Views
 	<epp:phrase id="Update/Views:jump_separator"> | </epp:phrase>
     <epp:phrase id="Update/Views:up_a_level"> Up a level</epp:phrase>
     <epp:phrase id="Update/Views:up_a_level_alt">[up]</epp:phrase>
-    <epp:phrase id="Update/Views:up_a_level_src">/style/images/multi_up.png</epp:phrase>
+    <epp:phrase id="Update/Views:up_a_level_src">/style/images/multi_up.svg</epp:phrase>
     <epp:phrase id="Update/Views:no_items"><p>No items in this section.</p></epp:phrase>
     <epp:phrase id="Update/Views:no_value">NULL</epp:phrase>
     <epp:phrase id="Update/Views:export_section">
@@ -2607,7 +2607,7 @@ Titles and Help for the System Fields
     <epp:phrase id="Plugin/Screen/Staff/HistorySearch:description">Search for actions that have occurred on items in this repository.</epp:phrase>
 
 
-    <epp:phrase id="sys:ep_form_required"><img src="{$config{rel_path}}/style/images/required.png" border="0" class="ep_required" alt="Required" style="display: inline"/>&nbsp;<epc:pin name="label"/></epp:phrase>
+    <epp:phrase id="sys:ep_form_required"><img src="{$config{rel_path}}/style/images/required.svg" border="0" class="ep_required" alt="Required" style="display: inline"/>&nbsp;<epc:pin name="label"/></epp:phrase>
     <epp:phrase id="sys:ep_form_required_src">/style/images/required.svg</epp:phrase>
     <epp:phrase id="sys:ep_form_required_alt">Required</epp:phrase>
 

--- a/perl_lib/EPrints/Plugin/InputForm/Component/Field/AjaxSubject.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Component/Field/AjaxSubject.pm
@@ -379,14 +379,14 @@ sub _render_subnode
 		$toggle = $self->{session}->make_element( "span", class=>"ep_only_js ep_subjectinput_toggle", id=>$id."_toggle" );
 
 		my $hide = $self->{session}->make_element( "span", id=>$id."_hide" );
-		$hide->appendChild( $self->{session}->make_element( "img", alt=>"-", src=>"/style/images/minus.png", border=>0 ) );
+		$hide->appendChild( $self->{session}->make_element( "img", alt=>"-", src=>"/style/images/minus.svg", border=>0 ) );
 		$hide->appendChild( $self->{session}->make_text( " " ) );
 		$hide->appendChild( $subject->render_description );
 		$hide->setAttribute( "class", join( " ", @classes ) );
 		$toggle->appendChild( $hide );
 
 		my $show = $self->{session}->make_element( "span", id=>$id."_show" );
-		$show->appendChild( $self->{session}->make_element( "img", alt=>"+", src=>"/style/images/plus.png", border=>0 ) );
+		$show->appendChild( $self->{session}->make_element( "img", alt=>"+", src=>"/style/images/plus.svg", border=>0 ) );
 		$show->appendChild( $self->{session}->make_text( " " ) );
 		$show->appendChild( $subject->render_description );
 		$show->setAttribute( "class", join( " ", @classes ) );


### PR DESCRIPTION
There are a couple of situations where missing `png` images have still slipped through. The main ones of these are some uses of `required` (notably the one used in the new JSON metafield) and `multi_up` (used to go up a level on view pages). This also replaces `minus` and `plus` on `AjaxSubject` although I'm not exactly sure what that is/is used for.

The boostrap changes have deleted the png versions of these images so they currently show as a broken image once you `generate_static --prune`.