### PR TITLE
Prevent RSS 2.0 from returning an Internal Server Error

### DIFF
--- a/perl_lib/EPrints/Plugin/Export/RSS2.pm
+++ b/perl_lib/EPrints/Plugin/Export/RSS2.pm
@@ -83,10 +83,12 @@ EOX
 			"rel"  => "self" ) );
 	}
 
+	my $desc = $session->config( 'oai', 'content', 'text' );
+	$desc ||= '';
 	$channel->appendChild( $session->render_data_element(
 		4,
 		"description", 
-		$session->config( "oai","content","text" ) ) );
+		$desc ) );
 
 	{
 		my $image = $session->make_element( "image" );


### PR DESCRIPTION
This copies a change made to RSS 1.0 in 849582f, preventing an undefined description from causing the whole process to crash.