### PR TITLE
Fix the PDF import failing if there are no EPrints

### DIFF
--- a/perl_lib/EPrints/Plugin/Import/PDF.pm
+++ b/perl_lib/EPrints/Plugin/Import/PDF.pm
@@ -92,7 +92,8 @@ sub generate_epdata
 	}
 
 	# Create a dummy workflow so that we can test whether it contains the 'contributions' field
-	my $workflow = EPrints::Workflow->new( $repository, 'default', ( item => EPrints::DataObj::EPrint->new( $repository, 1 ) ) );
+	my $fake_eprint = bless { dataset => $repository->dataset( 'eprint' ) }, 'EPrints::DataObj';
+	my $workflow = EPrints::Workflow->new( $repository, 'default', item => $fake_eprint );
 	my $has_contributions = $workflow->{field_stages}->{contributions} && 1;
 
 	# If it does contain contributions then we want to add the information to 'contributions' rather than 'creators'


### PR DESCRIPTION
Rather than using the first `EPrint` to get the workflow (and work out whether it contains `contributions`) this instead creates a fake `DataObj` that pretends to be an `EPrint`.

This creates a fake `DataObj` rather than a `DataObj::EPrint` because the `get_dataset` function (the only one that matters) is simpler in `DataObj` and only requires the `dataset` field.

Fixes #153