### PR TITLE
Make 'Refine search' fill in the old value for simple search

### DIFF
--- a/ingredients/eprints_classic_style/lang/en/phrases/ep_template.xml
+++ b/ingredients/eprints_classic_style/lang/en/phrases/ep_template.xml
@@ -1109,7 +1109,7 @@
         <input value="Search" type="hidden" name="screen" id="screen"/>
         <input value="archive" name="dataset" type="hidden" id="dataset"/>
         <input id="order" type="hidden" name="order"/>
-        <input type="text" name="q" size="60" aria-labelledby="{action_search}" value=""/>
+        <input type="text" name="q" size="60" aria-labelledby="{action_search}" value="{search_value}"/>
         <input name="_action_search" type="submit" id="{action_search}" value="{action_search}" role="button" class="ep_form_action_button"/>
         <input value="{advanced_link}" role="button" class="ep_form_action_button ep_form_search_advanced_link" name="_action_advanced" type="submit"/>
       </form>

--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1164,7 +1164,7 @@
         <input value="archive" name="dataset" type="hidden" id="dataset"/>
         <input id="order" type="hidden" name="order"/>
         <div class="col-auto">
-          <input class="form-control" type="text" name="q" size="60" aria-labelledby="{action_search}" value=""/>
+          <input class="form-control" type="text" name="q" size="60" aria-labelledby="{action_search}" value="{search_value}"/>
         </div>
         <div class="col-auto">
           <input name="_action_search" type="submit" id="{action_search}" value="{action_search}" role="button" class="btn btn-primary"/>

--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -315,6 +315,7 @@ sub render_simple_form
 
 	$item{action_search} = $self->{session}->phrase( "lib/searchexpression:action_search" );
 	$item{advanced_link} = $self->{session}->phrase( "lib/searchexpression:advanced_link" );
+	$item{search_value} = ($self->{processor}->{search}->get_non_filter_searchfields)[0]->get_value;
 
 	return( $session->template_phrase( 'view:EPrints/Plugin/Screen/Search:render_simple_form', { item => \%item } ) );
 }

--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -315,7 +315,16 @@ sub render_simple_form
 
 	$item{action_search} = $self->{session}->phrase( "lib/searchexpression:action_search" );
 	$item{advanced_link} = $self->{session}->phrase( "lib/searchexpression:advanced_link" );
-	$item{search_value} = ($self->{processor}->{search}->get_non_filter_searchfields)[0]->get_value;
+
+	# If 'Search::Xapian' is being used then the field is accessible from
+	# `$search->{q}` otherwise we want to use `get_non_filter_searchfields`
+	# (for 'Search::Internal').
+	my $search = $self->{processor}->{search};
+	if( defined $search->{q} ) {
+		$item{search_value} = $search->{q};
+	} else {
+		$item{search_value} = ($search->get_non_filter_searchfields)[0]->get_value;
+	}
 
 	return( $session->template_phrase( 'view:EPrints/Plugin/Screen/Search:render_simple_form', { item => \%item } ) );
 }


### PR DESCRIPTION
This is used by the 'Refine search' button to auto-fill the previous search value so that it can be modified.

The code to get the previous value comes from `Metafield`'s `render_search_input` which uses `get_value` and
`Plugin::Search::Internal`'s `render_simple_fields` which does the `get_non_filter_searchfields[0]`.

Fixes #150