### PR TITLE
Add a config function for how PDF import splits authors names

### DIFF
--- a/perl_lib/EPrints/Plugin/Import/PDF.pm
+++ b/perl_lib/EPrints/Plugin/Import/PDF.pm
@@ -184,27 +184,22 @@ sub get_info
 sub parse_author
 {
 	my( $plugin, $authors, $has_contributions ) = @_;
+	my $repo = $plugin->{repository};
 
 	my @parsed;
 	foreach my $author (split(/,|&| and |\t|;/, $authors)) {
-		my @words = split(' ', $author);
-		my $given = join(' ', @words[0..$#words-1]);
+		my $name = $repo->config( 'format_imported_author' )->( $author, $has_contributions );
 
 		if( $has_contributions ) {
 			push @parsed, {
 				type => $plugin->{repository}->config('entities', 'field_contribution_types', 'eprint', 'person', 'creators'),
 				contributor => {
 					datasetid => 'person',
-					name => $words[-1] . ', ' . $given,
+					name => $name,
 				}
 			}
 		} else {
-			push @parsed, {
-				name => {
-					given => $given,
-					family => $words[-1],
-				},
-			};
+			push @parsed, { name => $name };
 		}
 	}
 


### PR DESCRIPTION
Rather than hardcoding the behaviour on how a name is split into `<given>` and `<family>` and how `contributions` recombine these it has been separated into the `$c->{format_imported_author}` config function, keeping the exact same behaviour.

Fixes #140.

#### This includes a change to `pub_lib` that must be merged first.