### PR TITLE
Fix 'Template Tests' giving "no node passed to epc process"

### DIFF
--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1345,4 +1345,8 @@
       </div>
     </div>
   </epp:phrase>
+  <!-- This is used by 'Template Tests' to check it handles basic text entry -->
+  <epp:phrase id="view:basic_test">
+    Text only test entry.
+  </epp:phrase>
 </epp:phrases>


### PR DESCRIPTION
The problem was a missing phrase, removed in 9fdff57, so I have re-added that phrase and added a comment explaining why it is needed.

Fixes #145 