### PR TITLE
Fix saved simple searches not highlighting correctly

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -941,7 +941,7 @@ sub render
 
 		my %facet_fields = %{$self->get_facet_parameters()};
 		for my $key (keys %facet_fields) {
-			push @search_fields, { text => $facet_fields{$key}, field_name => $key, no_stemming => 1 };
+			push @search_fields, { text => $facet_fields{$key}, field_names => [ $key ], no_stemming => 1 };
 		}
 
 		$page = $self->render_search_highlights( $page, \@search_fields )
@@ -954,7 +954,7 @@ sub render
 
 =over 4
 
-=item $page = $screen->render_search_highlights( $page, $search_fields: [{text => <string/array[string]>, (field_name => <string>, ignore_apostrophes => <bool>, no_stemming => <bool>)?}, ...] )
+=item $page = $screen->render_search_highlights( $page, $search_fields: [{text => <string/array[string]>, (field_names => <array[string]>, ignore_apostrophes => <bool>, no_stemming => <bool>)?}, ...] )
 
 Adds the necessary javascript for search highlighting to the bottom of the $page.
 
@@ -962,7 +962,7 @@ Adds the necessary javascript for search highlighting to the bottom of the $page
 
 =item C<text> is the text we are highlighting. If this is a list of strings then it will search for each string, otherwise it will split into words and search for those
 
-=item C<field_name> is the field C<text> is being searched on ('undef' if it should apply generally). This can also be a list of field C<text>s which all have the same search applied.
+=item C<field_names> is an arrayref of the field C<text>s being searched on ('undef' if it should apply generally)
 
 =item C<ignore_apostrophes> tells us to ignore apostrophes (both ' and ’) placed anywhere throughout the word
 
@@ -983,31 +983,24 @@ sub render_search_highlights
 		my $regex = $self->generate_regex( $search_field->{text}, $search_field );
 
 		my $config = $repo->config( 'highlighted_search_selection' );
-		my $field_name = $search_field->{field_name};
+		my $field_names = $search_field->{field_names};
 
 		my $skip_highlighting = 1;
 		my $selection = undef;
-		if( ref $field_name eq 'ARRAY' ) {
-			# Combine all of the field names into a single selection, if any
-			# are '' then they take priority and `$selection` is set to ''
-			# otherwise it is a comma-separated list of selections.
-			for my $field_name (@{$field_name}) {
-				if( not exists $config->{$field_name} or defined $config->{$field_name} ) {
-					$skip_highlighting = 0;
-					if( not $config->{$field_name} ) {
-						$selection = '';
-					} elsif ( not defined $selection ) {
-						$selection = $config->{$field_name};
-					} elsif ( $selection ne '' ) {
-						$selection .= ',' . $config->{$field_name};
-					}
-				}
-			}
-		} else {
+		# Combine all of the field names into a single selection, if any
+		# are '' then they take priority and `$selection` is set to ''
+		# otherwise it is a comma-separated list of selections.
+		for my $field_name (@{$field_names}) {
 			# If the config doesn't exist then we want to use '*' but if it was set to 'undef' then we don't want to try to highlight
 			if( not exists $config->{$field_name} or defined $config->{$field_name} ) {
 				$skip_highlighting = 0;
-				$selection = $config->{$field_name};
+				if( not $config->{$field_name} ) {
+					$selection = '';
+				} elsif ( not defined $selection ) {
+					$selection = $config->{$field_name};
+				} elsif ( $selection ne '' ) {
+					$selection .= ',' . $config->{$field_name};
+				}
 			}
 		}
 

--- a/perl_lib/EPrints/Plugin/Search.pm
+++ b/perl_lib/EPrints/Plugin/Search.pm
@@ -542,8 +542,8 @@ Returns a list of all the fields involved in this search and some information as
 Each item is
 
  {
-     text => $text,
-	 field => $field_name, # (or C<undef> or an arrayref of $field_name)
+	 text => $text,
+	 field_names => [$field_name, ...], # (or C<undef>)
 	 ignore_apostrophes => C<bool>,
 	 no_stemming => C<bool>
  }

--- a/perl_lib/EPrints/Plugin/Search.pm
+++ b/perl_lib/EPrints/Plugin/Search.pm
@@ -539,7 +539,14 @@ sub describe
 
 Returns a list of all the fields involved in this search and some information as to how the search worked.
 
-Each item is {text => $text, field => $field_name (or C<undef>), ignore_apostrophes => C<bool>, no_stemming => C<bool>}.
+Each item is
+
+ {
+     text => $text,
+	 field => $field_name, # (or C<undef> or an arrayref of $field_name)
+	 ignore_apostrophes => C<bool>,
+	 no_stemming => C<bool>
+ }
 
 =cut
 sub get_highlightable_search_fields

--- a/perl_lib/EPrints/Plugin/Search/Internal.pm
+++ b/perl_lib/EPrints/Plugin/Search/Internal.pm
@@ -114,7 +114,7 @@ sub get_highlightable_search_fields
 	my @fields = $self->get_non_filter_searchfields();
 	for my $field (@fields) {
 		if( $field->is_set && $field->get_value ) {
-			push @search_terms, { text => $field->get_value, field_name => $field->get_field->name };
+			push @search_terms, { text => $field->get_value, field_name => $field->get_id };
 		}
 	}
 	return @search_terms;
@@ -126,8 +126,7 @@ sub find_embeddable_text
 
 	my @fields = $self->get_non_filter_searchfields();
 	for my $field (@fields) {
-		my $field_name = $field->get_field->name;
-		if( $field_name eq $search_field ) {
+		if( $field->get_id eq $search_field ) {
 			return $self->find_matching_embed( $field_text, $field->get_value );
 		}
 	}

--- a/perl_lib/EPrints/Plugin/Search/Internal.pm
+++ b/perl_lib/EPrints/Plugin/Search/Internal.pm
@@ -117,7 +117,7 @@ sub get_highlightable_search_fields
 			my @field_names = map { $_->get_name } @{$field->get_fields};
 			push @search_terms, {
 				text => $field->get_value,
-				field_name => \@field_names,
+				field_names => \@field_names,
 			};
 		}
 	}

--- a/perl_lib/EPrints/Plugin/Search/Internal.pm
+++ b/perl_lib/EPrints/Plugin/Search/Internal.pm
@@ -113,10 +113,12 @@ sub get_highlightable_search_fields
 	my @search_terms;
 	my @fields = $self->get_non_filter_searchfields();
 	for my $field (@fields) {
-		for my $metafield (@{$field->get_fields}) {
-			if( $field->is_set && $field->get_value ) {
-				push @search_terms, { text => $field->get_value, field_name => $metafield->get_name };
-			}
+		if( $field->is_set && $field->get_value ) {
+			my @field_names = map { $_->get_name } @{$field->get_fields};
+			push @search_terms, {
+				text => $field->get_value,
+				field_name => \@field_names,
+			};
 		}
 	}
 	return @search_terms;

--- a/perl_lib/EPrints/Plugin/Search/Internal.pm
+++ b/perl_lib/EPrints/Plugin/Search/Internal.pm
@@ -113,8 +113,10 @@ sub get_highlightable_search_fields
 	my @search_terms;
 	my @fields = $self->get_non_filter_searchfields();
 	for my $field (@fields) {
-		if( $field->is_set && $field->get_value ) {
-			push @search_terms, { text => $field->get_value, field_name => $field->get_id };
+		for my $metafield (@{$field->get_fields}) {
+			if( $field->is_set && $field->get_value ) {
+				push @search_terms, { text => $field->get_value, field_name => $metafield->get_name };
+			}
 		}
 	}
 	return @search_terms;
@@ -126,8 +128,10 @@ sub find_embeddable_text
 
 	my @fields = $self->get_non_filter_searchfields();
 	for my $field (@fields) {
-		if( $field->get_id eq $search_field ) {
-			return $self->find_matching_embed( $field_text, $field->get_value );
+		for my $metafield (@{$field->get_fields}) {
+			if( $metafield->get_name eq $search_field ) {
+				return $self->find_matching_embed( $field_text, $field->get_value );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Non-Xapian simple search is set up as a multi-field with an id `q` that then contains all of the fields it applies to (`documents`, `abstract` etc.). When a search happens normally it happens to place `documents` as the first inner item which doesn't have a filter associated with it and therefore highlights everything just fine. However when we save the search these get re-ordered to be alphabetical and `abstract` is limited to just the `embedded` field so it then only highlights that.

To fix this it now filters based on all of the sub-fields in a multi-field so it ends up selecting the broadest combination of the fields it filters on, which generally ends up being everything.

Fixes #163