### PR TITLE
Enable facets for non-Xapian simple search

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -911,13 +911,10 @@ sub render_results
 
 	my $results = $self->{session}->make_element("div", "class" => "ep_search_result_area");
 
-	if( $self->{processor}->{searchid} eq "advanced" )
-	{
-		my $facets_area = $self->{session}->make_element("div", "class" => "ep_facet_list");
-		$facets_area->appendChild( $self->render_facet_lists() );
+	my $facets_area = $self->{session}->make_element("div", "class" => "ep_facet_list");
+	$facets_area->appendChild( $self->render_facet_lists() );
 
-		$results->appendChild( $facets_area );
-	}
+	$results->appendChild( $facets_area );
 
 	my $results_area = $self->{session}->make_element("div", "class" => "ep_search_result_list");
 	$results_area->appendChild( $self->SUPER::render_results );


### PR DESCRIPTION
Faceted search was added in c739c62 but only enabled for advanced search so this just removes that limitation. This assumes there wasn't some particular reason it was limited to advanced (which I can't notice from a few simple tests).

Fixes #166.