### PR TITLE
Fixes failing unit tests

### DIFF
--- a/lib/cfg.d/contributions.pl
+++ b/lib/cfg.d/contributions.pl
@@ -372,8 +372,6 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 	my $primary_id_types = $repo->config( 'entities', 'primary_id_types' );
 	my $all_contrib_fields =  $repo->config( 'entities', 'field_contribution_types', 'eprint' );
 
-	return unless  $eprint->dataset->has_field( "contributions" );
-	
 	if ( $workflow->{field_stages}->{contributions} )
 	{
 		my $dataset = $repo->dataset( 'eprint' );
@@ -385,7 +383,7 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 			$entity_datasets->{$dsid} = $repo->dataset( $dsid );
 		}
 
-		my $contributions = $eprint->get_value( "contributions" );
+		my $contributions = $eprint->exists_and_set( 'contributions' ) ? $eprint->get_value( "contributions" ) : [];
 		my $changes = {};
 
 

--- a/tests/30_search.pl
+++ b/tests/30_search.pl
@@ -1,6 +1,6 @@
 use strict;
 use utf8;
-use Test::More tests => 35;
+use Test::More tests => 34;
 
 BEGIN { use_ok( "EPrints" ); }
 BEGIN { use_ok( "EPrints::Test" ); }


### PR DESCRIPTION
1. **tests/30_search.pl** was failing because we removed Xapian but did not update the number of tests for this unit test file.
2. **tests/99_missing_fields.pl** was failing because the `BEFORE_COMMIT` trigger in `lib/cfg/contributions.pl` did not gracefully handle the `contributions` field not being defined.