### PR TITLE
Pull in some more updates from 'richtext'

### DIFF
--- a/lib/static/javascript/auto/98_json_richtext.js
+++ b/lib/static/javascript/auto/98_json_richtext.js
@@ -1,6 +1,6 @@
-var initTinyMCE = function(id){
-        tinymce.init({
-                selector: id,
+var initJsonTinyMCE = function(id) {
+	tinymce.init({
+		selector: id,
 		height: 500,
 		width: 700,
 		menubar: false,
@@ -24,13 +24,13 @@ var initTinyMCE = function(id){
 				origElem.dispatchEvent(new Event('focusout'));
 			});
 		},
-        });
+	});
 };
 
 
-var initTinyMCEReadOnly = function(id){
-        tinymce.init({
-                selector: id,
+var initJsonTinyMCEReadOnly = function(id) {
+	tinymce.init({
+		selector: id,
 		height: 500,
 		width: 700,
 		menubar: false,
@@ -42,5 +42,5 @@ var initTinyMCEReadOnly = function(id){
 			'fullscreen', 'insertdatetime', 'media', 'table',
 		],
 		readonly: 1,
-        });
+	});
 };

--- a/lib/static/javascript/auto/98_json_richtext.js
+++ b/lib/static/javascript/auto/98_json_richtext.js
@@ -4,6 +4,8 @@ var initJsonTinyMCE = function(id) {
 		height: 500,
 		width: 700,
 		menubar: false,
+		relative_urls: false,
+		remove_script_host: false,
 		license_key: 'gpl', // TinyMCE is licensed under GPLv2+ so valid in LGPLv3
 		toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
 		plugins: [
@@ -34,6 +36,8 @@ var initJsonTinyMCEReadOnly = function(id) {
 		height: 500,
 		width: 700,
 		menubar: false,
+		relative_urls: false,
+		remove_script_host: false,
 		license_key: 'gpl', // TinyMCE is licensed under GPLv2+ so valid in LGPLv3
 		toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
 		plugins: [

--- a/lib/static/javascript/auto/98_richtext.js
+++ b/lib/static/javascript/auto/98_richtext.js
@@ -4,11 +4,12 @@ var initTinyMCE = function(id){
 		height: 500,
 		width: 700,
 		menubar: false,
+		license_key: 'gpl', // TinyMCE is licensed under GPLv2+ so valid in LGPLv3
 		toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
 		plugins: [
-			'advlist autolink lists link image charmap print preview anchor',
-			'searchreplace visualblocks code fullscreen',
-			'insertdatetime media table contextmenu paste code'
+			'advlist', 'autolink', 'lists', 'link', 'image', 'charmap',
+			'preview', 'anchor', 'searchreplace', 'visualblocks', 'code',
+			'fullscreen', 'insertdatetime', 'media', 'table',
 		],
 		setup: function(ed) {
 			ed.on('change', function(e) {
@@ -33,11 +34,12 @@ var initTinyMCEReadOnly = function(id){
 		height: 500,
 		width: 700,
 		menubar: false,
+		license_key: 'gpl', // TinyMCE is licensed under GPLv2+ so valid in LGPLv3
 		toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
 		plugins: [
-			'advlist autolink lists link image charmap print preview anchor',
-			'searchreplace visualblocks code fullscreen',
-			'insertdatetime media table contextmenu paste code'
+			'advlist', 'autolink', 'lists', 'link', 'image', 'charmap',
+			'preview', 'anchor', 'searchreplace', 'visualblocks', 'code',
+			'fullscreen', 'insertdatetime', 'media', 'table',
 		],
 		readonly: 1,
         });

--- a/perl_lib/EPrints/MetaField/Json.pm
+++ b/perl_lib/EPrints/MetaField/Json.pm
@@ -102,9 +102,9 @@ You can also specify the following:
 
 =over 4
 
-=item C<richtext_init_fun> - determines the function which initialises the TinyMCE richtext field. Default is C<initTinyMCE>, as defined in C<98_richtext.js>
+=item C<richtext_init_fun> - determines the function which initialises the TinyMCE richtext field. Default is C<initJsonTinyMCE>, as defined in C<98_json_richtext.js>
 
-=item C<richtext_init_fun_readonly> - determines the function which initialises the TinyMCE richtext field when readonly is true. Default is C<initTinyMCEReadOnly>, as defined in C<98_richtext.js>
+=item C<richtext_init_fun_readonly> - determines the function which initialises the TinyMCE richtext field when readonly is true. Default is C<initJsonTinyMCEReadOnly>, as defined in C<98_json_richtext.js>
 
 =item C<readonly> - set all fields readonly
 
@@ -762,8 +762,8 @@ sub get_property_defaults
 	my %defaults = $self->SUPER::get_property_defaults;
 
 	$defaults{json_config} = EP_PROPERTY_REQUIRED;
-	$defaults{richtext_init_func} = "initTinyMCE";
-	$defaults{richtext_init_func_readonly} = "initTinyMCEReadOnly";
+	$defaults{richtext_init_func} = "initJsonTinyMCE";
+	$defaults{richtext_init_func_readonly} = "initJsonTinyMCEReadOnly";
 
 	$defaults{readonly_fields} = EP_PROPERTY_UNDEF;
 	$defaults{hidden_fields} = EP_PROPERTY_UNDEF;


### PR DESCRIPTION
This pulls in:
- https://github.com/eprints/richtext/pull/10
- https://github.com/eprints/richtext/pull/12
- https://github.com/eprints/richtext/pull/11

It also applies the relative link fix (and upgrade changes) to the json richtext field and separates this field further from the base richtext by renaming its initialisation functions (and their file).