### PR TITLE
Re-add the 'register with ROAR' message to 'epadmin create'

### DIFF
--- a/bin/epadmin
+++ b/bin/epadmin
@@ -698,6 +698,8 @@ or:
 And then try connecting to your repository.
 --------------------------------------------------------------------------
 
+Don't forget to register your repository at https://roar.eprints.org/
+
 END
 	}
 


### PR DESCRIPTION
This was removed in bd1879c when 'epadmin create' was expanded to support creation from a YAML file.

This re-adds the line how it was except changes `http` to `https` as it redirects anyway.