### PR TITLE
Remove the final bits of jQuery from core

### DIFF
--- a/cgi/cal
+++ b/cgi/cal
@@ -4,8 +4,10 @@ use strict;
 # renders a calendar for embedded in other pages via ajax
 #
 # note the use of &amp; when using from an xpage, else use &
-#  fetch('/cgi/cal?year=2017&amp;w=25&amp;m=8').then((data) => {
-#    document.getElementById('mycal').insertAdjacentHTML('beforeend', data);
+#  fetch('/cgi/cal?year=2017&amp;w=25&amp;m=8').then((res) => {
+#    res.text().then((data) => {
+#      document.getElementById('mycal').insertAdjacentHTML('beforeend', data);
+#    });
 #  });
 
 my $session = EPrints::Session->new();

--- a/cgi/cal
+++ b/cgi/cal
@@ -4,11 +4,8 @@ use strict;
 # renders a calendar for embedded in other pages via ajax
 #
 # note the use of &amp; when using from an xpage, else use &
-#  jQuery.ajax({url: "/cgi/cal?year=2017&amp;w=25&amp;m=8",
-#    success:function(data)
-#    {
-#      jQuery('#mycal').append(data);
-#    }
+#  fetch('/cgi/cal?year=2017&amp;w=25&amp;m=8').then((data) => {
+#    document.getElementById('mycal').insertAdjacentHTML('beforeend', data);
 #  });
 
 my $session = EPrints::Session->new();

--- a/perl_lib/EPrints/MetaField/Longtext_counter.pm
+++ b/perl_lib/EPrints/MetaField/Longtext_counter.pm
@@ -15,8 +15,6 @@ B<EPrints::MetaField::Longtext_counter> Longtext input field with character coun
 
 =head1 DESCRIPTION
 Renders the input field with additional character counter.
-Requires javascript/jquery.min.js in static folder. 
-This will define jquery $ as $j to avoid conflict with prototype.
 
 =over 4
 
@@ -77,44 +75,32 @@ sub get_basic_input_elements
 
 
 $frag->appendChild( $session->make_javascript( <<EOJ ) );
-jQuery.noConflict();
 function getWordCount(words_string)
 {
 	var words = words_string.split(/\\W+/);
-        var word_count = words.length;
-        if (word_count > 0 && words[word_count-1] == "")
-        {
-                word_count--;
-        }
+	var word_count = words.length;
+	if (word_count > 0 && words[word_count-1] == "")
+	{
+		word_count--;
+	}
 	return word_count;
 }
-jQuery.fn.wordCount = function(max_words)
-{
-	var counterLine = "counter_line";
-        var counterElement = "display_count";
-        var cid = jQuery(this).attr('id');
-        var total_words;
+document.addEventListener('DOMContentLoaded', () => {
+	const element = document.getElementById('$basename');
+	const counterDisplay = document.getElementById('${basename}_display_count');
+	const counterLine = document.getElementById('${basename}_counter_line');
 
-        //for each keypress function on text areas
-        jQuery(this).bind("input propertychange", function()
-        {
-		total_words = getWordCount(this.value);
-                jQuery('#'+cid+"_"+counterElement).html(total_words);
-		console.log("total_words: "+total_words+" | max_words: "+max_words);
-		if (total_words > max_words )
-		{
-			jQuery('#'+cid+"_"+counterLine).attr('class', 'ep_over_word_limit');
+	element.addEventListener('input', () => {
+		const totalWords = getWordCount(element.value);
+		counterDisplay.innerText = totalWords;
+		if (totalWords > $self->{maxwords}) {
+			counterLine.setAttribute('class', 'ep_over_word_limit');
+		} else if (counterLine.getAttribute('class') === 'ep_over_word_limit') {
+			counterLine.removeAttribute('class');
 		}
-		else if (jQuery('#'+cid+"_"+counterLine).attr('class') == "ep_over_word_limit")
-		{
-			jQuery('#'+cid+"_"+counterLine).attr('class', '');
-		}
-        });
-	total_words = getWordCount(jQuery(this).text());
-        jQuery('#'+cid+"_"+counterElement).html(total_words);
-};
-jQuery( document ).ready(function() {
-	jQuery("#$basename").wordCount($self->{maxwords});
+	});
+
+	counterDisplay.innerText = getWordCount(element.value);
 });
 EOJ
 

--- a/perl_lib/EPrints/MetaField/Longtext_counter.pm
+++ b/perl_lib/EPrints/MetaField/Longtext_counter.pm
@@ -85,7 +85,8 @@ function getWordCount(words_string)
 	}
 	return word_count;
 }
-document.addEventListener('DOMContentLoaded', () => {
+
+{
 	const element = document.getElementById('$basename');
 	const counterDisplay = document.getElementById('${basename}_display_count');
 	const counterLine = document.getElementById('${basename}_counter_line');
@@ -100,8 +101,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	});
 
-	counterDisplay.innerText = getWordCount(element.value);
-});
+	const totalWords = getWordCount(element.value);
+	counterDisplay.innerText = totalWords;
+	if (totalWords > $self->{maxwords}) {
+		counterLine.setAttribute('class', 'ep_over_word_limit');
+	}
+}
 EOJ
 
 


### PR DESCRIPTION
This removes the final uses of jQuery in core which were `Longtext_counter` and some documentation in `cgi/cal` and `easy_pages`. This should unblock the removal of `jquery4eprints` (#183).

#### This includes changes to `easy_pages` so will need https://github.com/eprints/easy_pages/pull/6 merging first

This pulls in slightly more from `easy_pages` than just the documentation change as it also gets https://github.com/eprints/easy_pages/commit/a17142e7728a432e09a10f2f9811ba0146d60171 as it is on main.