### PR TITLE
Prevent facets from being reset when the search is re-ordered

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -146,6 +146,13 @@ sub hidden_bits
 		$bits{dataset} = $self->{processor}->{dataset}->id;
 	}
 
+	# Don't reset the facets if we re-order the search results
+	for my $key ( $self->{repository}->param() ) {
+		if( $key =~ /^facet_/ ) {
+			$bits{$key} = $self->{repository}->param( $key );
+		}
+	}
+
 	return %bits;
 }
 


### PR DESCRIPTION
This works by adding all `facet_*` params to `hidden_bits` which allows them to be automatically included in the reorder url and therefore persist.

Fixes #177 