### PR TITLE
Sanitize pid value incase of proc_exists misuse

### DIFF
--- a/perl_lib/EPrints/System.pm
+++ b/perl_lib/EPrints/System.pm
@@ -505,6 +505,12 @@ sub proc_exists
 {
 	my( $self, $pid ) = @_;
 
+	if ( $pid =~ m/[^0-9]/ )
+	{
+		print STDERR "ERROR: You can only check a procoess exists if its PID is an integer\n";
+		return 0;
+	}
+
 	return `ls /proc/ | grep '^$pid\$' | wc -l`;
 }
 


### PR DESCRIPTION
Although it would require code to be written beyond core that calls `EPrints::System::proc_exists` without making sure the value for `$pid` could not be malicious.  As this could allow escape to shell with a carefully crafted value, it seems sensible to sanitize the value (actually just disallow anything that is not a non-negative integer).