### PR TITLE
Add support for key presses to the lightbox

### DIFF
--- a/lib/static/javascript/auto/40_lightbox.js
+++ b/lib/static/javascript/auto/40_lightbox.js
@@ -28,13 +28,13 @@ class Lightbox {
 		document.querySelector('body').appendChild(fragment);
 
 		// Close if the overlay, lightbox or close button is pressed.
-		Lightbox.overlayElement.addEventListener('click', Lightbox.close);
-		Lightbox.closeButton.addEventListener('click', Lightbox.close);
+		Lightbox.overlayElement.addEventListener('click', this.close);
+		Lightbox.closeButton.addEventListener('click', this.close);
 		// We only want to close on the lightbox if the event hasn't
 		// bubbled as this means we have clicked off to the side whereas if
 		// it bubbles then we clicked somewhere on the image or its border.
 		Lightbox.lightboxElement.addEventListener('click', (ev) => {
-			if (ev.srcElement === ev.currentTarget) Lightbox.close(ev);
+			if (ev.srcElement === ev.currentTarget) this.close(ev);
 		});
 
 		Lightbox.prevButton.addEventListener('click', (ev) => {
@@ -87,6 +87,9 @@ class Lightbox {
 		Lightbox.lightboxImage.style.display = 'none';
 		Lightbox.prevButton.style.display = 'none';
 		Lightbox.nextButton.style.display = 'none';
+
+		Lightbox.keyHandler = (ev) => { this.handleKey(ev); };
+		document.addEventListener('keydown', Lightbox.keyHandler);
 
 		this.setImage(group, index);
 	}
@@ -153,7 +156,7 @@ class Lightbox {
 	}
 
 	// Close the lightbox and fade the overlay out
-	static close(ev) {
+	close(ev) {
 		// Fade the overlay from 0.8 to 0.0 in 200ms
 		let fadeIndex = 0;
 		const intervalId = setInterval(() => {
@@ -167,9 +170,25 @@ class Lightbox {
 
 		Lightbox.lightboxElement.style.display = 'none';
 
-		// This is a '#' link so if we don't prevent default it jumps to the
-		// top of the page when closing.
+		document.removeEventListener('keydown', Lightbox.keyHandler);
+
+		// This is often a '#' link so if we don't prevent default it jumps to
+		// the top of the page when closing.
 		ev.preventDefault();
+	}
+
+	handleKey(ev) {
+		switch (ev.key) {
+			case 'Escape':
+				this.close(ev);
+				break;
+			case 'ArrowLeft':
+				this.prev();
+				break;
+			case 'ArrowRight':
+				this.next();
+				break;
+		}
 	}
 }
 


### PR DESCRIPTION
This adds `Esc`, `ArrowLeft` and `ArrowRight` support when the lightbox is open where `Esc` will close the lightbox, `ArrowLeft` will move to the previous picture and `ArrowRight` will move to the next picture.

This was a part of the old prototypejs solution however I accidentally forgot about it in my re-creation (#184). Prototype also supported `P` and `N` for switching between images however that feels largely unintuitive so I haven't currently implemented it.