### PR TITLE
Various CSS tweaks for #137

### DIFF
--- a/lib/static/style/auto/actions.css
+++ b/lib/static/style/auto/actions.css
@@ -42,7 +42,7 @@ dl.ep_action_list dt:first-child {
 dl.ep_action_list dd {
 	position: relative;
 	left: 16em;
-	top: -.5em;
+	top: -.7em;
 	margin-right: 16em;
 	overflow: hidden;
 }

--- a/lib/static/style/auto/colors.css
+++ b/lib/static/style/auto/colors.css
@@ -58,9 +58,7 @@ h1, h2, h3, h4 {
 	color: #606060;
 }
 .ep_tm_searchbar, .ep_columns_title, td.ep_columns_alter {
-	background-color: #ccc;
-	background-image: url(images/bar_24px.png);
-	background-repeat: repeat-x;
+	background-color: transparent;
 }
 .ep_tm_searchbarbox {
 	border-color: #606060;
@@ -110,7 +108,7 @@ h1, h2, h3, h4 {
 ,.ep_search_buttons, .ep_search_controls, .ep_search_controls_bottom /* search.css */
 ,.ep_view_group_by /* view.css */
 {
-	background-color: #e8e8ff;
+	background-color: #ffffff;
 }
 .ep_summary_box_title, .ep_sr_title_bar, .ep_sr_collapse_bar {
 	background-image: url(images/bar_solid_12px.png);
@@ -121,8 +119,6 @@ h1, h2, h3, h4 {
 .ep_toolbox_content /* toolbox.css */
 /* upload.css */
 {
-	background-image: url(images/bar_solid_24px.png);
-	background-repeat: repeat-x;
 }
 .ep_summary_box_title, .ep_summary_box_body, .ep_sr_title_bar, .ep_sr_content, .ep_sr_collapse_bar
 ,.ep_tab_panel, .ep_tab_bar li, .ep_tab_bar li a
@@ -134,14 +130,10 @@ h1, h2, h3, h4 {
 
 /* tabs.css */
 
-.ep_tab_bar li a {
-	background-image: url(images/bar_solid_24px.png);
-	background-repeat: repeat-x;
-}
 
 /* unselected tab */
 .ep_tab_bar li a {
-	background-color: #bbf;
+	background-color: #f0f0f0; 
 }
 
 /* selected tab */
@@ -154,19 +146,11 @@ h1, h2, h3, h4 {
 th.ep_title_row
 {
 	border-color: #808080;
-	background-image: url(images/bar_24px.png);
-	background-color: #ccc;
 	color: #333;
 }
 
 th.ep_row, td.ep_row {
 	border-color: #bbb;
-}
-th.ep_row, td.ep_row {
-	border-bottom-style: dashed;
-}
-td.ep_row {
-	border-left-style: dashed;
 }
 
 /* messages.css */

--- a/lib/static/style/auto/columns.css
+++ b/lib/static/style/auto/columns.css
@@ -3,29 +3,33 @@
 
 .ep_columns {
 	margin: auto;
+	border: 1px solid #888;
+	border-radius: 5%;
 }
 
 td.ep_columns_cell {
-	border-style: none dashed solid none;
+	border-style: none none solid none;
 	border-width: 1px;
+	border-color: #ccc;
 }
-td.ep_columns_cell:first-child {
-	border-left-style: dashed;
-}
+
 
 th.ep_columns_title, td.ep_columns_alter {
 	border-width: 1px;
 	font-weight: normal;
 }
+
 th.ep_columns_title {
-	border-style: solid solid solid none;
+	border-style: none none solid none;
 }
 td.ep_columns_alter {
-	border-style: none solid solid none;
+	border-style: solid none none none;
 }
 th.ep_columns_title:first-child, td.ep_columns_alter:first-child {
 	border-left-style: solid;
 }
+
+
 th.ep_columns_title a {
 	font-weight: normal;
 }
@@ -47,7 +51,8 @@ td.ep_columns_no_items {
 .ep_columns_title_inner, .ep_columns_alter_inner {
 	display: table;
 	border-width: 0; 
-	width: 100%;
+	margin-left:auto;
+	margin-right: auto;
 }
 
 .ep_columns_title_inner > div, .ep_columns_alter_inner > div {
@@ -57,22 +62,6 @@ td.ep_columns_no_items {
 .ep_columns_title_inner > div > div, .ep_columns_alter_inner > div > div {
         display: table-cell;
 }
-
-.ep_columns_alter_inner > div > div:nth-child(1) {
-	text-align: left;
-	width: 14px;
-}
-
-.ep_columns_alter_inner > div > div:nth-child(2) {
-        text-align: center;
-	width: 100%;
-}
-
-.ep_columns_alter_inner > div > div:nth-child(3) {
-        text-align: right;
-	width: 14px;
-}
-
 
 .ep_columns_title_inner_sort {
 	width: 22px; 
@@ -84,4 +73,3 @@ td.ep_columns_no_items {
 	border: 0px;
 	padding: 4px;
 }
-

--- a/lib/static/style/auto/datasets.css
+++ b/lib/static/style/auto/datasets.css
@@ -1,0 +1,3 @@
+.ep_datasets_table td, .ep_datasets_table th {
+	border: 0px;
+}

--- a/lib/static/style/auto/fields.css
+++ b/lib/static/style/auto/fields.css
@@ -43,3 +43,12 @@ dl.ep_field_set_long dd {
 .ep_itemref_desc {
 	padding: 0 0.5em;
 }
+
+.ep_field_set_long > dd
+{
+	padding-left: 0.5em;
+}
+
+.ep_field_legend {
+	display: none;
+}

--- a/lib/static/style/auto/general.css
+++ b/lib/static/style/auto/general.css
@@ -39,12 +39,15 @@ h1 {
 	text-align: center;
 }
 h2 {
+	padding-top: 1rem;
 	font-size: 1.8em;
 }
 h3 {
+	padding-top: 0.8rem;
 	font-size: 1.5em;
 }
 h4 {
+	padding-top: 0.6rem;;
 	font-size: 1.2em;
 }
 
@@ -107,9 +110,9 @@ th.ep_title_row {
 	border-left: none;
 	border-right: none;
 	padding: 0.1em 0.5em 0.1em 0.5em;
-	font-size: 100%;
+	font-size: 125%;
 	height: 2em;
-	font-weight: normal;
+	font-weight: bold;
 }
 
 .ep_title_row_inner {

--- a/lib/static/style/auto/search.css
+++ b/lib/static/style/auto/search.css
@@ -122,3 +122,7 @@ span.search_desc {
     margin: 0.4em 0 0 auto;
     text-align: center;
 }
+
+.input-group select {
+	border-color: #ccc;
+}

--- a/lib/static/style/auto/summary.css
+++ b/lib/static/style/auto/summary.css
@@ -29,15 +29,17 @@
 
 
 .ep_summary_box {
-	margin-bottom: 10px
+	margin-bottom: 10px;
 }
 .ep_summary_box_title {
 	font-weight: normal;
-	padding: 2px 6px 2px 6px; 
+	padding: 2px 6px 3px 6px; 
 	font-weight: bold;
 	font-size: 115%;
 	border-style: solid;
 	border-width: 1px;
+	background-color: transparent;
+	border-radius: var(--bs-border-radius) !important;
 }
 .ep_summary_box_body {
 	padding: 2px 6px 2px 6px; 
@@ -49,7 +51,7 @@
 }
 .ep_summary_box_title img
 {
-	vertical-align: -1px;
+	vertical-align:  middle;
 }
 
 .ep_summary_page_actions dt {

--- a/lib/static/style/auto/tabs.css
+++ b/lib/static/style/auto/tabs.css
@@ -63,3 +63,9 @@
 .ep_tab_panel > div > table {
 	width: 100%;
 }
+
+.ep_tab_panel .btn {
+	min-width: 12em;
+	max-width: 12em;
+	white-space: normal;
+}


### PR DESCRIPTION
I have tried to tackle some of the issue reported in #137 -

- Spacing between title and description on eprints workflow type field and similar fields needs better defaults.
- Very old-style dark grey background used at the top and bottom of listing tables needs reconsidering.
- Reconsider borders round table on "Manage records" page.
- Reconsider dark-grey graded background on the section banner of Workflow::View::Details pages
- Reintroduce minimum button width so Admin tabs lists of buttons don't look so untidy.
- Reconsider styling for Any/All dropdowns on search forms when appearing alongside a multi-select input (just altered border colour to stand out less, maybe still want to change background colour on options list).
-  Remove dotted line beneath selected subjects in Subjects stage of eprint workflow.
-  Better spacing between headings on Status, Database Schema, Template test pages. Also consider removing table borders (on first two).