### PR TITLE
Allow facet fields to be specified as config strings

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -777,12 +777,17 @@ sub render_facet_list
 
 	my( $values, $counts ) = $search->perform_groupby( $field );
 
-	my @result;
-	my $num_results = scalar @{$counts};
+	# Combine the counts of items with shared ids (for example with `date?res=year`)
+	my %id_list = ();
+	for (my $index = 0; $index < scalar @{$counts}; $index++) {
+		next unless defined $values->[$index];
+		my $key = $field->get_id_from_value( $session, $values->[$index] );
+		$id_list{$key} += $counts->[$index];
+	}
 
-	for (my $index = 0; $index < $num_results; $index++)
-	{
-		push @result, { count => $counts->[$index], value => $values->[$index] };
+	my @result;
+	for my $value (keys %id_list) {
+		push @result, { count => $id_list{$value}, value => $value };
 	}
 
 	my @sorted_result = sort { $b->{count} <=> $a->{count} } @result;

--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -592,7 +592,7 @@ sub get_facet_config
 			field_id => "publication"
 		},
 		{
-			field_id => "date"
+			field_id => "date;res=year"
 		},	];
 }
 
@@ -729,14 +729,16 @@ sub render_facet_list
 {
 	my( $self, $facet_config ) = @_;
 
-	my $max_facet_list_length = 6;
-
-	my $facet = $facet_config->{field_id};
-
 	my $session = $self->{session};
 
 	my $search = $self->{processor}->{search};
 	my $dataset = $self->{processor}->{dataset};
+
+
+	my $max_facet_list_length = 6;
+
+	my $field = EPrints::Utils::field_from_config_string( $dataset, $facet_config->{field_id} );
+	my $facet = $field->name;
 
 	my %current_values;
 	my $existing_param = $session->param( "facet_$facet" );
@@ -759,8 +761,6 @@ sub render_facet_list
 
 	$base_url->query_form( @query );
 	$base_url->query( undef ) if !@query;
-
-	my $field = $self->{processor}->{dataset}->get_field( $facet );
 
 	my $list = $session->make_element( "div" );
 


### PR DESCRIPTION
This allows the `date` facet to instead be specified as `date?res=year` which will then combine anything with the same year (for example `2023`, `2023-04` and `2023-07-12`) into the same facet selection box.

Fixes #170.