### PR TITLE
Prevent facets from reordering when the page is reloaded

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -790,7 +790,8 @@ sub render_facet_list
 		push @result, { count => $id_list{$value}, value => $value };
 	}
 
-	my @sorted_result = sort { $b->{count} <=> $a->{count} } @result;
+	# Sort by count and if those match then sort alphabetically
+	my @sorted_result = sort { ($b->{count} <=> $a->{count}) || ($a->{value} cmp $b->{value}) } @result;
 
 
 	my $show_this_facet = 0;


### PR DESCRIPTION
While facets are sorted so that the more numerous terms are at the top, any terms with the same count are ordered randomly which means that they can switch anytime the page reloads (such as when you select a facet).

To prevent this I've added a secondary sort for alphabetical so that iff the count matches they will then be sorted A-Z (An annoying quirk of this is that years will be sorted oldest to newest as that is alphabetical).