### PR TITLE
Fix a crash when importing an EPrint with an ID'd contributor

### DIFF
--- a/lib/cfg.d/contributions.pl
+++ b/lib/cfg.d/contributions.pl
@@ -416,7 +416,7 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 			{
 				if ( $contribution->{contributor}->{id_type} )
 				{
-					$entity = EPrints::DataObj::Entity::entity_with_id( $entity_datasets->{$contribution->{contributor}->{datasetid}}, $contribution->{contributor}->{id_value}, type => $contribution->{contributor}->{id_type} );
+					$entity = EPrints::DataObj::Entity::entity_with_id( $entity_datasets->{$contribution->{contributor}->{datasetid}}, $contribution->{contributor}->{id_value}, { type => $contribution->{contributor}->{id_type} } );
 				}
 				else
 				{


### PR DESCRIPTION
If you create a new EPrint that already has a contributor with the `id_value` and `id_type` fields (aka from an import) it will hit this line which tries to pass the bare-word `type` to `Entity::entity_with_id`.

This is because `entity_with_id` takes a hash-ref rather than a hash so it can't be passed an un-packed hash.