### PR TITLE
Fix the Longtext_counter word limit highlighting with new styling

### DIFF
--- a/ingredients/eprints_classic_style/static/style/auto/form.css
+++ b/ingredients/eprints_classic_style/static/style/auto/form.css
@@ -181,8 +181,3 @@ select, input.ep_form_text, textarea {
 	float: left;
 	clear: both;
 }
-
-.ep_over_word_limit {
-	color: red;
-	font-weight: bold;
-}

--- a/lib/static/style/auto/fields.css
+++ b/lib/static/style/auto/fields.css
@@ -43,3 +43,9 @@ dl.ep_field_set_long dd {
 .ep_itemref_desc {
 	padding: 0 0.5em;
 }
+
+/* Used by Longtext_counter to highlight when it is over the word limit*/
+.ep_over_word_limit {
+	color: red;
+	font-weight: bold;
+}


### PR DESCRIPTION
`Longtext_counter` uses `ep_over_word_limit` to highlight when a textbox is over the word count limit (for example '23/20 words'). However the highlighting for this was moved to `eprints_classic_style` in 97f65c1 with the rest of `form.css` so it fails to highlight when you go over the word limit.