### PR TITLE
Teach 'contributions_contributor' meta tag not to show a hash-ref

### DIFF
--- a/perl_lib/EPrints/Plugin/Export/Simple.pm
+++ b/perl_lib/EPrints/Plugin/Export/Simple.pm
@@ -108,6 +108,11 @@ sub convert_dataobj
 				{
 					push @epdata, [ $fieldname, ($item->{family}||"").", ".($item->{given}||"") ];
 				}
+				elsif( $field->is_type( 'multipart' ) ) {
+					for my $subfieldname (keys %$item) {
+						push @epdata, [ $fieldname . '_' . $subfieldname, $item->{$subfieldname} ];
+					}
+				}
 				else
 				{
 					push @epdata, [ $fieldname, $item ];


### PR DESCRIPTION
The `contributions_contributor` field is a `Multipart` which the "Simple" meta-tags (aka the `eprints.` ones) didn't properly handle however they also weren't filtered out by anything as they are for example included in EP3 XML exports (correctly).

Meta-tags don't support nesting and while there are in theory some ways to sort of nest them via link tags it isn't very satisfactory so this just splits multiparts (specifically those in 'multiple' fields) into their separate fields so 'contributions_contributor' becomes 'contributions_contributor_datasetid', 'contributions_contributor_name' and 'contributions_contributor_entityid' (and possibly 'contributions_contributor_id_value' and
'contributions_contributor_id_type').

The alternative solution I came up with is to simply filter this field out so it isn't included in the tags at all however it does contain useful information so this seemed the more sensible solution.

Fixes #207.