### PR TITLE
Fix accessing phrases from JavaScript

### DIFF
--- a/lib/static/javascript/auto/00_ep_js_lib.js
+++ b/lib/static/javascript/auto/00_ep_js_lib.js
@@ -381,6 +381,7 @@ const xhrRequest = (url, options) => {
 	}
 
 	xhr.open(options.method.toUpperCase(), url, true);
+	xhr.responseType = options.responseType || '';
 	xhr.send(body);
 
 	xhr.onload = function(e) {

--- a/lib/static/javascript/auto/89_component_documents.js
+++ b/lib/static/javascript/auto/89_component_documents.js
@@ -123,14 +123,14 @@ class Component_Documents {
 		{
 			xhrRequest(url, {
 				method: 'post',
+				responseType: 'json',
 				onException: function(response) {
 					alert( "AJAX Exception: Status " + response.status + " " + response.statusText );
 				},
 				onSuccess: (function(response) {
-					var json = JSON.parse(response.response);
-					if (!json)
-					{
-						alert('Expected JSON but got: ' + response.response);
+					const json = response.response;
+					if (!json) {
+						alert('Expected JSON but got: ' + response.responseText);
 						return;
 					}
 					this.update_documents(json.documents);
@@ -169,7 +169,7 @@ class Component_Documents {
 			onSuccess: (function(transport) {
 				this.loading.style.display = 'none';
 				this.lightboxMovie = document.getElementById('lightboxMovie');
-				this.lightboxMovie.innerHTML = transport.response;
+				this.lightboxMovie.innerHTML = transport.responseText;
 			
 				var boxWidth = this.lightboxMovie.offsetWidth;
 				if( boxWidth == null || boxWidth < 640 ) {
@@ -207,16 +207,16 @@ class Component_Documents {
 
 		xhrRequest(url, {
 			method: form.method,
+			responseType: 'json',
 			onException: function(response) {
 				alert( "AJAX Exception: Status " + response.status + " " + response.statusText );
 			},
 			onSuccess: (function(transport) {
 				this.lightbox.style.display = 'none';
 				this.overlay.style.display = 'none';
-				var json = JSON.parse(transport.response);
-				if (!json)
-				{
-					alert ('Expected JSON but got: ' + transport.response);
+				const json = transport.response;
+				if (!json) {
+					alert('Expected JSON but got: ' + transport.responseText);
 					return;
 				}
 				this.update_documents(json.documents);

--- a/lib/static/javascript/auto/99_eprints_api.js
+++ b/lib/static/javascript/auto/99_eprints_api.js
@@ -22,19 +22,20 @@ class EPrintsRepository {
 		xhrRequest(
 			url, 
 			{
-                        	method: 'post',
-                        	onException: (response) => {
+				method: 'post',
+				responseType: 'json',
+				onException: (response) => {
 					alert( "AJAX Exception: Status " + response.status + " " + response.statusText );
-                        	},
-                        	onFailure: (response) => {
-                                	throw new Error ('Error ' + response.status + ' requesting phrases (check server log for details)');
-                        	},
-                        	onSuccess: (response) => {
-                                	if (!response.response) throw new Error ('Failed to get JSON from phrases callback');
-                                	f (response.response);
-                        	},
-                        	postBody: JSON.stringify(phrases)
-                	}
+				},
+				onFailure: (response) => {
+					throw new Error ('Error ' + response.status + ' requesting phrases (check server log for details)');
+				},
+				onSuccess: (response) => {
+					if (!response.response) throw new Error ('Failed to get JSON from phrases callback');
+					f (response.response);
+				},
+				postBody: JSON.stringify(phrases)
+			}
 		);
 	}
 

--- a/lib/static/javascript/screen_batchedit.js
+++ b/lib/static/javascript/screen_batchedit.js
@@ -60,8 +60,9 @@ class Screen_BatchEdit {
 			var url = eprints_http_cgiroot + '/users/ajax/upload_progress?progressid='+uuid;
 			xhrRequest(url, {
 				method: 'get',
+				responseType: 'json',
 				onSuccess: (transport) => {
-					var json = JSON.parse(transport.response);
+					const json = transport.response;
 					if( !json ) {
 						clearInterval(container.intervalID);
 						return;


### PR DESCRIPTION
This was broken by the switch to use `xhrRequest` rather than `Ajax.Request` as `XMLHttpRequest` makes no assumptions about the data being returned (even when it is **right there** in the 'Content-Type'). This means that all phrase requests (such as the 'Cancel' text when uploading a document or the 'Document too large' text) would just show up as `undefined` or '' (depending on how they are used).

The way this has been fixed in existing cases is to add a layer of JSON parsing on top of the request however there is a mechanism for this in `XMLHttpRequest` so it makes sense to use it. To do this we add another optional field 'responseType' to `xhrRequest` that defaults to '' and therefore it can be set to 'json' rather than needing to resort to parsing it ourselves.

This also changes one existing `.response` to `.responseText` as while it was already correct (because `.response` will default to parsing as text) it feels best to be clear in cases when we want text (which could theoretically allow defaulting to `responseType: 'json'`).