### PR TITLE
Emit a REMOVED trigger when a user is deleted

### DIFF
--- a/perl_lib/EPrints/DataObj/User.pm
+++ b/perl_lib/EPrints/DataObj/User.pm
@@ -873,24 +873,12 @@ but do not remove their eprints.
 sub remove
 {
 	my( $self ) = @_;
-	
-	my $success = 1;
 
-	foreach my $saved_search ( $self->get_saved_searches )
-	{
+	for my $saved_search( $self->get_saved_searches ) {
 		$saved_search->remove;
 	}
 
-	# clean-up citation cache for this item
-	$self->clear_citationcaches() if defined $self->{session}->config( "citation_caching", "enabled" ) && $self->{session}->config( "citation_caching", "enabled" ) && $self->{dataset}->confid ne "citationcache";
-
-	# remove user record
-	my $user_ds = $self->{session}->get_repository->get_dataset( "user" );
-	$success = $success && $self->{session}->get_database->remove(
-		$user_ds,
-		$self->get_value( "userid" ) );
-	
-	return( $success );
+	return $self->SUPER::remove();
 }
 
 


### PR DESCRIPTION
This replaces the custom implementation of `User::remove` with a call to the general implementation and an extra little section to handle saved searches (which appear to be the only special part of User's removal code, although some of it was worded differently).

Fixes #74.