### PR TITLE
Vertically align the items in multiple Compound fields

### DIFF
--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -592,7 +592,7 @@
               <epc:if test="$cell{column_index} = 0">
                 <epc:attribute name="class">
                   <epc:if test="has_col_titles">
-					py-1 px-1 d-table-cell
+					py-1 px-1 d-table-cell align-middle
 				</epc:if>
                   <epc:if test="!has_col_titles">
 					w-100
@@ -600,7 +600,7 @@
                 </epc:attribute>
               </epc:if>
               <epc:if test="$cell{column_index} != 0">
-                <epc:attribute name="class">py-1 px-1 d-table-cell</epc:attribute>
+                <epc:attribute name="class">py-1 px-1 d-table-cell align-middle</epc:attribute>
               </epc:if>
               <epc:print expr="$cell{item}"/>
             </div>


### PR DESCRIPTION
The items in a `multiple => 1` `Compound` field wouldn't line up across the row since the change to Bootstrap `d-table-cell` so this adds the `align-middle` bootstrap class which applies `vertical-align: middle`.

While these issues were particularly pronounced on Safari, I have tested this fix on both Safari and Firefox (while the items didn't collide on Firefox the buttons and numbers still weren't lined up with the input boxes previously).

Fixes #213.

Previously (from #213):
<img width="619" height="141" alt="Screenshot 2025-09-03 at 4 47 44 PM" src="https://github.com/user-attachments/assets/f0516864-6c05-41f6-b0e0-36f936a42786" />
Now:
<img width="609" height="141" alt="Screenshot 2025-09-03 at 4 58 32 PM" src="https://github.com/user-attachments/assets/2794fca3-cb44-4a21-8ba0-ec229074ad52" />
