### PR TITLE
Fix toggling when 'show_help => always'

### DIFF
--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1232,16 +1232,32 @@
               </div>
               <div align="right">
                 <div class="ep_only_js">
-                  <div class="ep_sr_show_help ep_toggle " id="{help_item{prefix}}_show">
-                    <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
-                      <img border="0" src="/style/images/help.svg" title="Show help" alt="+"/>
-                    </a>
-                  </div>
-                  <div class="ep_sr_hide_help ep_toggle ep_hide" id="{help_item{prefix}}_hide">
-                    <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
-                      <img border="0" src="/style/images/minus.svg" title="Hide help" alt="-"/>
-                    </a>
-                  </div>
+                  <epc:choose>
+                  <epc:when test="is_collapsed">
+                    <div class="ep_sr_show_help ep_toggle" id="{help_item{prefix}}_show">
+                      <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
+                        <img border="0" src="/style/images/help.svg" title="Show help" alt="?"/>
+                      </a>
+                    </div>
+                    <div class="ep_sr_hide_help ep_toggle ep_hide" id="{help_item{prefix}}_hide">
+                      <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
+                        <img border="0" src="/style/images/minus.svg" title="Hide help" alt="-"/>
+                      </a>
+                    </div>
+                  </epc:when>
+                  <epc:otherwise>
+                    <div class="ep_sr_show_help ep_toggle ep_hide" id="{help_item{prefix}}_show">
+                      <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',true);EPJS_toggle('{help_item{prefix}}_hide',true);EPJS_toggle('{help_item{prefix}}_show',false);return false">
+                        <img border="0" src="/style/images/help.svg" title="Show help" alt="?"/>
+                      </a>
+                    </div>
+                    <div class="ep_sr_hide_help ep_toggle" id="{help_item{prefix}}_hide">
+                      <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',true);EPJS_toggle('{help_item{prefix}}_hide',true);EPJS_toggle('{help_item{prefix}}_show',false);return false">
+                        <img border="0" src="/style/images/minus.svg" title="Hide help" alt="-"/>
+                      </a>
+                    </div>
+                  </epc:otherwise>
+                  </epc:choose>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
When `show_help` is set to 'always' for a workflow component (such as for 'Add a new document' in the default EPrint workflow) it starts open and so the toggle button should start by shrinking it. However instead the icon would show as '?' (rather than the '-' it should be) and the first time you press it it re-opens the already open tab.

To fix this we check whether the help panel is collapsed and use that to determine the initial state of the icons (and whether `toggleSlide` is set to expand first). This also tweaks the alt-text for the '?' button to be a question mark rather than a plus icon as the help icon is now a question mark.

For example, this should be '-' as the help is already open:
<img width="556" height="298" alt="image" src="https://github.com/user-attachments/assets/78c8c0fb-3a2b-4895-8315-d5154f92ad5f" />