### PR TITLE
Fix 'Contributor ID Type' not defaulting when clearing the row

### DIFF
--- a/lib/cfg.d/contributions.pl
+++ b/lib/cfg.d/contributions.pl
@@ -305,7 +305,7 @@ $c->{render_input_contributions} = sub {
 		my $contrib_fields = $self->{dataset}->get_field( 'contributions' )->get_property( 'fields' );
 		$defaults{type} = $contrib_fields->[0]->{default_value} if defined $contrib_fields->[0]->{default_value};
 		$defaults{contributor_datasetid} = $contrib_fields->[1]->{fields}->[0]->{default_value} if defined $contrib_fields->[1]->{fields}->[0]->{default_value};
-		$defaults{contributor_id_type} = $contrib_fields->[1]->{fields}->[2]->{default_value} if defined $contrib_fields->[1]->{fields}->[2]->{default_value};
+		$defaults{contributor_id_type} = $contrib_fields->[1]->{fields}->[3]->{default_value} if defined $contrib_fields->[1]->{fields}->[3]->{default_value};
 	}
 	$extra_params->query_form( @params );
 	$extra_params = "&" . $extra_params->query;


### PR DESCRIPTION
When using `unset_entity` to clear a row of the 'Contributions' field it correctly filled 'Type' and 'Entity Type' with their defaults but would clear 'Contributor ID Type' to `UNSPECIFIED` (rather than `Email`) because its the 4th item not the 3rd.

#### This is effectively superseded by #218 (as that deletes this button entirely)