### PR TITLE
Remove a mention to the 'CHANGELOG' file from 'NEWS'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,6 @@
 This file describes the major changes between versions. In addition you
 can assume every new version fixes minor bugs and typos. If you want to
-see the blow by blow account of every single change see the file called
-CHANGELOG.
+see the blow by blow account of every single change use `git log`.
 ======================================================================
 
 =========================================================================


### PR DESCRIPTION
There is no file called 'CHANGELOG' and from what I can tell from `git log --all --full-history -- "*CHANGELOG*"` it hasn't existed for a long time (the git history only dates to the beginning of 3.4 but it didn't exist then). As such it seems unhelpful to link to this in 'NEWS' so I have changed it to suggest using `git log` as this will at least give you a history (although likely both too in-depth and un-specific to be helpful).