### PR TITLE
Prevent opening a collapsible component stuttering

### DIFF
--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1241,8 +1241,8 @@
           </a>
         </div>
       </epc:if>
-      <div id="{prefix}_content" class="{content{class}} bg-white p-2 rounded">
-        <div id="{content_inner{id}}">
+      <div id="{prefix}_content" class="{content{class}} bg-white rounded">
+        <div id="{content_inner{id}}" class="p-2">
           <epc:comment>Add the help text if it is included, generally starts hidden (unless !no_toggle)</epc:comment>
           <epc:if test="has_help">
             <div id="{help_item{prefix}}" class="{help_item{hide_class}}">


### PR DESCRIPTION
This was previously fixed in #148 for help boxes however it still happened for collapsible elements (like 'Contact Email Address').

It was caused by the `scaleEffectOpen` function not correctly handling elements with padding (as it sets the height but padding is handled separately) and so was fixed by just shifting the padding in a layer so that the div that we expand has no padding and therefore its height includes the padding of the internal element.