### PR TITLE
Allow collapsible items with a value to still collapse

### DIFF
--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1195,9 +1195,9 @@
         <div class="d-flex justify-content-between">
           <div id="{title_div{id}}" class="ep_sr_title">
             <epc:choose>
-              <epc:comment>Add the minus button to the left of collapsible components (defaults to hidden)</epc:comment>
-              <epc:when test="is_collapsed">
-                <a onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',false,'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',true);EPJS_toggle('{col_link{barid}}',false);return false" class="ep_only_js ep_toggle ep_sr_collapse_link text-black">
+              <epc:comment>Add the minus button to the left of collapsible components (defaults to hidden unless the component has a value (!is_collapsed))</epc:comment>
+              <epc:when test="can_collapse">
+                <a onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',{!is_collapsed},'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',{is_collapsed});EPJS_toggle('{col_link{barid}}',{!is_collapsed});return false" class="ep_only_js ep_toggle ep_sr_collapse_link text-black">
                   <img alt="-" src="/style/images/minus.svg" style="margin-right: 5px;" border="0">
                     <epc:print expr="col_link{render_title}"/>
                   </img>
@@ -1231,10 +1231,10 @@
           </epc:if>
         </div>
       </div>
-      <epc:comment>Add the plus button to the left of collapsible components (can't be with the '-' button as the whole of `{title_bar{id}}` is hidden</epc:comment>
-	  <epc:if test="is_collapsed">
-        <div class="p-2 bg-white rounded ep_only_js ep_toggle" id="{col_div{id}}">
-          <a class="ep_sr_collapse_link text-black" onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',false,'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',true);EPJS_toggle('{col_link{barid}}',false);return false">
+      <epc:comment>Add the plus button to the left of collapsible components (can't be with the '-' button as the whole of `{title_bar{id}}` is hidden)</epc:comment>
+	  <epc:if test="can_collapse">
+        <div class="p-2 bg-white rounded ep_only_js ep_toggle {col_div{class}}" id="{col_div{id}}">
+          <a class="ep_sr_collapse_link text-black" onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',{!is_collapsed},'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',{is_collapsed});EPJS_toggle('{col_link{barid}}',{!is_collapsed});return false">
             <img alt="+" src="/style/images/plus.svg" style="margin-right: 5px;" border="0">
               <epc:print expr="col_link{render_title}"/>
             </img>

--- a/perl_lib/EPrints/Plugin/InputForm/Surround/Default.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Surround/Default.pm
@@ -60,10 +60,14 @@ sub render
 	my $barid = $component->{prefix}."_titlebar";
 	my $title_bar_class="";
 	my $content_class="";
+	my $col_div_class="";
 	if( $component->is_collapsed )
 	{
 		$title_bar_class = "ep_no_js";
 		$content_class = "ep_no_js";
+	} elsif( $component->{collapse} )
+	{
+		$col_div_class = "ep_no_js";
 	}
 		
 	$item->{title_bar} = { class => $title_bar_class, id => $barid };
@@ -85,10 +89,11 @@ sub render
 	$item->{ajax_content_target} = { id => $component->{prefix}."_ajax_content_target" };
 	$item->{contents} = $component->render_content( $self );
 	$item->{is_collapsed} = $component->is_collapsed;
-	if( $component->is_collapsed )
+	$item->{can_collapse} = $component->{collapse}; # If the component is collapsible (even if it currently has a value)
+	if( $component->{collapse} )
 	{
 		my $colbarid = $component->{prefix}."_col";
-		$item->{col_div} = { id => $colbarid };
+		$item->{col_div} = { id => $colbarid, class => $col_div_class };
 
 		my $contentid = $component->{prefix}."_content";
 		my $main_id = $component->{prefix};

--- a/perl_lib/EPrints/Script.pm
+++ b/perl_lib/EPrints/Script.pm
@@ -106,7 +106,7 @@ sub print
 	}
 	if( $result->[1] eq "BOOLEAN"  )
 	{
-		return $state->{session}->make_text( $result->[0]?"TRUE":"FALSE" );
+		return $state->{session}->make_text( $result->[0]?"true":"false" );
 	}
 	if( $result->[1] eq "STRING"  )
 	{


### PR DESCRIPTION
If you add some text to a collapsible component on an EPrint and then save and reload the form it would prevent you from shrinking that component again.

This was caused by the `MetaField->can_collapse` function which checks whether it currently contains a value (or for `Multi` whether any of the fields contains a value). This is then read by `Component->is_collapsed` so to check whether a field is collapsible (irrespective) of whether it is currently collapsed we can just read `Component->{collapse}`.

This then controls which elements are set to `ep_no_js` (aka hidden off the bat) and the '+' and '-' buttons are informed whether they start visible or not.

Fixes https://github.com/eprints/eprints3.5/issues/222.

#### NB: This includes a change to `EPrints/Script.pm` that could have wider repercussions. I don't believe it breaks anything but it is worth at least thinking about.