### PR TITLE
Allow the 'clear' button to handle more field types

### DIFF
--- a/lib/static/javascript/auto/87_component_field.js
+++ b/lib/static/javascript/auto/87_component_field.js
@@ -71,9 +71,11 @@ function Component_Field_Action(e, inputName, inputValue, prefix) {
 }
 
 const EPJS_clear_row = (basename, index) => {
-	const inputs = document.querySelectorAll(`input[id^=${basename}_${index}_]`);
+	const inputs = document.querySelectorAll(`input[id^=${basename}_${index}_],textarea#${basename}_${index}`);
 	inputs.forEach((el) => {
 		el.value = '';
+		// Ensure the longtext word counter is updated
+		el.dispatchEvent(new Event('input'));
 	});
 
 	const selects = document.querySelectorAll(`select[id^=${basename}_${index}_]`);
@@ -97,6 +99,14 @@ const EPJS_clear_row = (basename, index) => {
 	spans.forEach((el) => {
 		el.innerHTML = '';
 	});
+
+	// Clear a richtext field if tinymce is defined
+	if (tinymce) {
+		const richtext = tinymce.get(`${basename}_${index}`);
+		if (richtext) {
+			richtext.setContent('');
+		}
+	}
 
 	return false;
 };


### PR DESCRIPTION
Longtext elements use `textarea` not `input` so they would not correctly clear when pressing the 'clear button' (#218). It also has a slightly different ID pattern for some reason.

Richtext fields were also not being cleared as they use an embedded iframe that then updates a textarea (unreliably) in the background. While it is possible to directly clear this iframe it seems much more sane to use the `tinymce` methods to do this instead.

This also handles an edge case around the 'longtext counter' field as this uses the 'input' event which is only triggered automatically by _user_ input. This would mean that the word count would remain as `x/20` until you enter some new text into the field.