### PR TITLE
Make clicking the description of a radio button count as the button

### DIFF
--- a/perl_lib/EPrints/MetaField/Boolean.pm
+++ b/perl_lib/EPrints/MetaField/Boolean.pm
@@ -172,8 +172,9 @@ sub get_basic_input_elements
 			$dt->appendChild( $inputs->{$option} );
 			$f->appendChild( $dt );
 			my $dd = $session->make_element( "dd", class=>"d-inline", id => $basename . "_" . $option . "_label" );
-			$dd->appendChild( $session->html_phrase( $self->{confid} . "_radio_" . $self->{name} . "_" . $option ) ) unless $option eq "unspecified";
-			$dd->appendChild( $self->unspecified_phrase( $session ) ) if $option eq "unspecified";
+			my $label = $dd->appendChild( $session->make_element( 'label', for => "${basename}_$option" ) );
+			$label->appendChild( $session->html_phrase( $self->{confid} . "_radio_" . $self->{name} . "_" . $option ) ) unless $option eq "unspecified";
+			$label->appendChild( $self->unspecified_phrase( $session ) ) if $option eq "unspecified";
 			$f->appendChild( $dd );
 			$f->appendChild( $session->make_element( "br" ) );
 		}

--- a/perl_lib/EPrints/MetaField/Set.pm
+++ b/perl_lib/EPrints/MetaField/Set.pm
@@ -295,7 +295,7 @@ sub render_set_input
 		my $row;
 		if( $input_style eq "long" || $input_style eq "medium" )
 		{
-			$row = $session->make_element( "dt", class => "d-inline", id => $basename."_".$opt."_title" );
+			$row = $session->make_element( "dt", class => "d-inline pe-1", id => $basename."_".$opt."_title" );
         	        my $checked = undef;
                 	my $type = "radio";
 	                if( $self->{multiple} )
@@ -329,8 +329,9 @@ sub render_set_input
 				) );
 	                	$row->appendChild( $session->make_text( " ".$labels->{$opt} ));
         	        	$dd = $session->make_element( "dd", class => "d-inline", id=>$basename."_".$opt."_desc" );
+						my $label = $dd->appendChild( $session->make_element( 'label', for => "${basename}_$opt" ) );
                 		my $phrasename = $self->{confid}."_optdetails_".$self->{name}."_".$opt;
-                		$dd->appendChild( $session->html_phrase( $phrasename ));
+                		$label->appendChild( $session->html_phrase( $phrasename ));
 			}
 			else 
 			{
@@ -344,11 +345,12 @@ sub render_set_input
 	                                checked => $checked,
         	                        'aria-labelledby' => $basename."_".$opt."_title",
                 	        ) );
-	                        $dd = $session->make_element( "dd", class => "d-inline", id=>$basename."_".$opt."_label", 'aria-describedby'=>$self->get_labelledby( $basename ) );
-				$dd->appendChild( $session->make_text( " ".$labels->{$opt} ) );
+				$dd = $session->make_element( "dd", class => "d-inline", id=>$basename."_".$opt."_label", 'aria-describedby'=>$self->get_labelledby( $basename ) );
+				my $label = $dd->appendChild( $session->make_element( 'label', for => "${basename}_$opt" ) );
+				$label->appendChild( $session->make_text( $labels->{$opt} ) );
 			}
 			$list->appendChild( $row );
-                        $list->appendChild( $dd );
+			$list->appendChild( $dd );
 			$list->appendChild( $session->make_element( "br" ) );
 		}
 		else


### PR DESCRIPTION
The convention is for radio buttons to be controllable by the text next to them so this uses `label`s tracking the `input`s.

This is a 3.5 version of eprints/eprints3.4#520 as it requires some slightly layout tweaks that are different in 3.4 (notably the addition of `pe-1` to the header element).

Fixes #227.