### PR TITLE
Prevent reordering richtext components from clearing their contents

### DIFF
--- a/lib/static/javascript/auto/87_component_field.js
+++ b/lib/static/javascript/auto/87_component_field.js
@@ -38,6 +38,19 @@ class Component_Field {
 }
 
 function Component_Field_Action(e, inputName, inputValue, prefix) {
+	// If the elements are richtext then they need to be saved before we
+	// serialise the form, otherwise they will be cleared.
+	if (tinymce) {
+		const [_, basename, index] = /^_internal_(.*?)(?:_down_|_up_)(\d*)$/.exec(inputName);
+		// Check that this is a richtext field before doing too much work.
+		if (tinymce.get(`${basename}_${index}`)) {
+			const spaces = document.getElementById(`${basename}_spaces`).value;
+			for (let i = 1; i <= spaces; i++) {
+				tinymce.get(`${basename}_${i}`).save();
+			}
+		}
+	}
+
 	root = document.getElementById(prefix);
 	form = root.closest('form');
 	let params = serializeForm (form);


### PR DESCRIPTION
This is a slightly hacky fix but it checks how many items are in the `multiple` component and then loops through them all, saving each one.

This will also attempt to do the same thing when re-ordering non-richtext fields but `tinymce.get` will just return `null` causing it to be ignored.

Fixes #226, #229.