### PR TITLE
Switch to CSS transitions for expanding sections

### DIFF
--- a/ingredients/eprints_classic_style/lang/en/phrases/ep_template.xml
+++ b/ingredients/eprints_classic_style/lang/en/phrases/ep_template.xml
@@ -757,8 +757,8 @@
       <epc:choose>
         <epc:when test="has_help">
           <div class="ep_multi_input ep_table_cell" colspan="{if (has_toggle, '1', '2')}" id="{help_prefix}_outer">
-            <div id="{help_prefix}" class="ep_multi_inline_help {if (has_toggle, 'ep_no_js')}">
-              <div id="{help_prefix}_inner" role="definition" aria-labelledby="{prefix}_label">
+            <div id="{help_prefix}" class="ep_toggleable {if (has_toggle, 'ep_no_js')}">
+              <div id="{help_prefix}_inner" class="ep_multi_inline_help" role="definition" aria-labelledby="{prefix}_label">
                 <epc:print expr="help"/>
               </div>
             </div>
@@ -774,16 +774,11 @@
       <epc:choose>
         <epc:when test="has_toggle">
           <div class="ep_multi_help ep_only_js_table_cell ep_toggle ep_table_cell">
-            <div class="ep_sr_show_help ep_only_js" id="{help_prefix}_show">
-              <a onclick="EPJS_toggleSlide('{help_prefix}',false,'block');EPJS_toggle('{help_prefix}_hide',false,'block');EPJS_toggle('{help_prefix}_show',true,'block');return false" href="#">
-                <img alt="{string_phrase(&quot;lib/session:show_help_alt&quot;)}" title="{string_phrase(&quot;lib/session:show_help_title&quot;)}" src="{string_phrase(&quot;lib/session:show_help_src&quot;)}"/>
-              </a>
-            </div>
-            <div class="ep_sr_hide_help ep_hide" id="{help_prefix}_hide">
-              <a onclick="EPJS_toggleSlide('{help_prefix}',false,'block');EPJS_toggle('{help_prefix}_hide',false,'block');EPJS_toggle('{help_prefix}_show',true,'block');return false" href="#">
-                <img alt="{string_phrase(&quot;lib/session:hide_help_alt&quot;)}" title="{string_phrase(&quot;lib/session:hide_help_title&quot;)}" src="{string_phrase(&quot;lib/session:hide_help_src&quot;)}"/>
-              </a>
-            </div>
+            <label class="ep_styled_checkbox">
+              <input type="checkbox" id="{help_prefix}_checkbox" onclick="EPJS_checkboxSlide('{help_prefix}');" />
+              <img class="ep_unchecked" src="/style/images/help.png" alt="?" />
+              <img class="ep_checked" src="/style/images/minus.png" alt="-" />
+            </label>
           </div>
         </epc:when>
         <epc:otherwise>
@@ -1131,80 +1126,49 @@
       <epc:foreach expr="handled_fields" iterator="handled_field">
         <epc:print expr="$handled_field{handled_field}"/>
       </epc:foreach>
-      <div id="{title_bar{id}}" class="ep_sr_title_bar {title_bar{class}}">
-        <epc:if test="!has_help">
-          <div id="{title_div{id}}" class="ep_sr_title">
-            <epc:choose>
-              <epc:when test="is_collapsed">
-                <a onclick="EPJS_toggleSlideScroll('{contentid}',false,'{main_id}');EPJS_toggle('{colbarid}',true);EPJS_toggle('{barid}',false);return false" class="ep_only_js ep_toggle ep_sr_collapse_link">
-                  <img alt="+" src="/style/images/minus.png" border="0">
+      <div id="{title_bar{id}}" class="ep_sr_title_bar">
+        <div class="ep_sr_title_bar_inner">
+          <div>
+            <div id="{title_div{id}}" class="ep_sr_title">
+              <epc:choose>
+                <epc:when test="can_collapse">
+                  <label class="ep_only_js ep_styled_checkbox">
+                    <input type="checkbox" id="{prefix}_content_checkbox" onclick="EPJS_checkboxSlide('{prefix}_content');">
+                      <epc:if test="!is_collapsed">
+                        <epc:attribute name="checked">checked</epc:attribute>
+                      </epc:if>
+                    </input>
+                    <img class="ep_unchecked" src="/style/images/plus.png" alt="+" />
+                    <img class="ep_checked" src="/style/images/minus.png" alt="-" />
+                    <span class="align-middle"><epc:print expr="col_link{render_title}" /></span>
+                  </label>
+                  <div class="ep_no_js">
                     <epc:print expr="col_link{render_title}"/>
-                  </img>
-                </a>
-                <div class="ep_no_js">
-                  <epc:print expr="col_link{render_title}"/>
-                </div>
-              </epc:when>
-              <epc:otherwise>
-                <epc:print expr="render_title"/>
-              </epc:otherwise>
-            </epc:choose>
-          </div>
-        </epc:if>
-        <epc:if test="!no_toggle and has_help">
-          <div class="ep_sr_title_bar_inner">
-            <div>
-              <div>
-                <div id="{title_div{id}}" class="ep_sr_title">
-                  <epc:choose>
-                    <epc:when test="is_collapsed">
-                      <a onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',false,'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',true);EPJS_toggle('{col_link{barid}}',false);return false" class="ep_only_js ep_toggle ep_sr_collapse_link">
-                        <img alt="+" src="/style/images/minus.png" style="margin-right: 5px;" border="0">
-                          <epc:print expr="col_link{render_title}"/>
-                        </img>
-                      </a>
-                      <div class="ep_no_js">
-                        <epc:print expr="col_link{render_title}"/>
-                      </div>
-                    </epc:when>
-                    <epc:otherwise>
-                      <epc:print expr="render_title"/>
-                    </epc:otherwise>
-                  </epc:choose>
-                </div>
-              </div>
-              <div align="right">
-                <div class="ep_only_js">
-                  <div class="ep_sr_show_help ep_toggle " id="{help_item{prefix}}_show">
-                    <a onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
-                      <img border="0" src="/style/images/help.png" title="Show help" alt="+"/>
-                    </a>
                   </div>
-                  <div class="ep_sr_hide_help ep_toggle ep_hide" id="{help_item{prefix}}_hide">
-                    <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
-                      <img border="0" src="/style/images/minus.png" title="Hide help" alt="-"/>
-                    </a>
-                  </div>
-                </div>
-              </div>
+                </epc:when>
+                <epc:otherwise>
+                  <epc:print expr="render_title"/>
+                </epc:otherwise>
+              </epc:choose>
             </div>
+            <div />
+            <epc:if test="!no_toggle and has_help">
+              <div align="right" class="ep_only_js">
+                <label class="ep_styled_checkbox">
+                  <input type="checkbox" id="{help_item{prefix}}_checkbox" onclick="EPJS_checkboxSlide('{help_item{prefix}}');" />
+                  <img class="ep_unchecked" src="/style/images/help.png" title="Show help" alt="?" />
+                  <img class="ep_checked" src="/style/images/minus.png" title="Hide help" alt="-" />
+                </label>
+              </div>
+            </epc:if>
           </div>
-        </epc:if>
-      </div>
-      <epc:if test="is_collapsed">
-        <div class="ep_sr_collapse_bar ep_only_js ep_toggle" id="{col_div{id}}">
-          <a class="ep_sr_collapse_link" onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',false,'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',true);EPJS_toggle('{col_link{barid}}',false);return false">
-            <img alt="+" src="/style/images/plus.png" style="margin-right: 5px;" border="0">
-              <epc:print expr="col_link{render_title}"/>
-            </img>
-          </a>
         </div>
-      </epc:if>
-      <div id="{prefix}_content" class="{content{class}} ep_sr_content">
-        <div id="{content_inner{id}}">
+      </div>
+      <div id="{prefix}_content" class="{content{class}} ep_toggleable">
+        <div id="{prefix}_content_inner" class="ep_sr_content">
           <epc:if test="has_help">
-            <div id="{help_item{prefix}}" class="ep_sr_help {help_item{hide_class}}">
-              <div id="{help_item{prefix}}_inner" class="">
+            <div id="{help_item{prefix}}" class="{help_item{hide_class}} ep_toggleable">
+              <div id="{help_item{prefix}}_inner" class="ep_sr_help">
                 <epc:print expr="help_item{render_help}"/>
               </div>
             </div>
@@ -1260,23 +1224,20 @@
         </div>
       </div>
       <div class="ep_upload_doc_expansion_bar ep_only_js">
-        <a onclick="EPJS_toggleSlideScroll('{doc_prefix}_opts',{if(hide, 'false', 'true')},'{doc_prefix}_block');EPJS_toggle('{doc_prefix}_opts_hide',{if(hide, 'false', 'true')},'block');EPJS_toggle('{doc_prefix}_opts_show',{if (hide, 'true','false')},'block');return false">
-          <div id="{doc_prefix}_opts_show" class="ep_update_doc_options {if (hide, '','ep_hide')}">
-            <label for="{doc_prefix}_opts_show">
-              <epc:print expr="show_label"/>
-            </label>
-            <input type="image" src="{imagesurl}/style/images/plus.svg" alt="+" id="{doc_prefix}_opts_show"/>
-          </div>
-          <div id="{doc_prefix}_opts_hide" class="ep_update_doc_options {if (hide, 'ep_hide', '')}">
-            <label for="{doc_prefix}_opts_hide">
-              <epc:print expr="hide_label"/>
-            </label>
-            <input type="image" src="{imagesurl}/style/images/minus.svg" alt="-" id="{doc_prefix}_opts_hide"/>
-          </div>
-        </a>
+	    <label class="ep_styled_checkbox ms-auto">
+          <input type="checkbox" id="{doc_prefix}_opts_checkbox" onclick="EPJS_checkboxSlide('{doc_prefix}_opts');">
+            <epc:if test="!hide"><epc:attribute name="checked">checked</epc:attribute></epc:if>
+          </input>
+
+          <span class="ep_unchecked align-middle"><epc:print expr="show_label"/></span>
+          <img class="ep_unchecked ms-1" src="/style/images/plus.png" title="Show options" alt="+" />
+
+          <span class="ep_checked align-middle"><epc:print expr="hide_label"/></span>
+          <img class="ep_checked ms-1" src="/style/images/minus.png" title="Hide options" alt="-" />
+        </label>
       </div>
-      <div class="ep_upload_doc_content {if (hide, 'ep_no_js', '')}" id="{doc_prefix}_opts">
-        <div class="" id="{doc_prefix}_opts_inner">
+      <div class="ep_toggleable {if (hide, 'ep_no_js', '')}" id="{doc_prefix}_opts">
+        <div class="ep_upload_doc_content" id="{doc_prefix}_opts_inner">
           <epc:print expr="doc_metadata"/>
         </div>
       </div>

--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1186,17 +1186,22 @@
       <epc:foreach expr="handled_fields" iterator="handled_field">
         <epc:print expr="$handled_field{handled_field}"/>
       </epc:foreach>
-      <div id="{title_bar{id}}" class="p-2 bg-white rounded {title_bar{class}}">
+      <div id="{title_bar{id}}" class="p-2 bg-white rounded">
         <div class="d-flex justify-content-between">
           <div id="{title_div{id}}" class="ep_sr_title">
             <epc:choose>
-              <epc:comment>Add the minus button to the left of collapsible components (defaults to hidden unless the component has a value (!is_collapsed))</epc:comment>
+              <epc:comment>Add the plus/minus checkbox to the left of collapsible components (defaults to plus unless the component has a value (!is_collapsed))</epc:comment>
               <epc:when test="can_collapse">
-                <a onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',{!is_collapsed},'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',{is_collapsed});EPJS_toggle('{col_link{barid}}',{!is_collapsed});return false" class="ep_only_js ep_toggle ep_sr_collapse_link text-black">
-                  <img alt="-" src="/style/images/minus.svg" style="margin-right: 5px;" border="0">
-                    <epc:print expr="col_link{render_title}"/>
-                  </img>
-                </a>
+                <label class="ep_styled_checkbox">
+                  <input type="checkbox" id="{prefix}_content_checkbox" onclick="EPJS_checkboxSlide('{prefix}_content');">
+                    <epc:if test="!is_collapsed">
+                      <epc:attribute name="checked">checked</epc:attribute>
+                    </epc:if>
+                  </input>
+                  <img class="ep_unchecked" src="/style/images/plus.svg" alt="+" />
+                  <img class="ep_checked" src="/style/images/minus.svg" alt="-" />
+                  <span class="align-middle"><epc:print expr="col_link{render_title}" /></span>
+                </label>
                 <div class="ep_no_js">
                   <epc:print expr="col_link{render_title}"/>
                 </div>
@@ -1209,38 +1214,24 @@
           </div>
           <epc:comment>Add the question and minus buttons to the right of a component with toggleable help (defaults to '?')</epc:comment>
           <epc:if test="!no_toggle and has_help">
-            <div align="right">
-              <div class="ep_only_js">
-                <div class="ep_sr_show_help ep_toggle " id="{help_item{prefix}}_show">
-                  <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
-                    <img border="0" src="/style/images/help.svg" title="Show help" alt="?"/>
-                  </a>
-                </div>
-                <div class="ep_sr_hide_help ep_toggle ep_hide" id="{help_item{prefix}}_hide">
-                  <a href="#" onclick="EPJS_toggleSlide('{help_item{prefix}}',false);EPJS_toggle('{help_item{prefix}}_hide',false);EPJS_toggle('{help_item{prefix}}_show',true);return false">
-                    <img border="0" src="/style/images/minus.svg" title="Hide help" alt="-"/>
-                  </a>
-                </div>
-              </div>
+            <div class="ep_only_js">
+              <label class="ep_styled_checkbox">
+                <input type="checkbox" id="{help_item{prefix}}_checkbox" onclick="EPJS_checkboxSlide('{help_item{prefix}}');" />
+                <img class="ep_unchecked" src="/style/images/help.svg" title="Show help" alt="?" />
+                <img class="ep_checked" src="/style/images/minus.svg" title="Hide help" alt="-" />
+              </label>
             </div>
           </epc:if>
         </div>
       </div>
-      <epc:comment>Add the plus button to the left of collapsible components (can't be with the '-' button as the whole of `{title_bar{id}}` is hidden)</epc:comment>
-	  <epc:if test="can_collapse">
-        <div class="p-2 bg-white rounded ep_only_js ep_toggle {col_div{class}}" id="{col_div{id}}">
-          <a class="ep_sr_collapse_link text-black" onclick="EPJS_toggleSlideScroll('{col_link{contentid}}',{!is_collapsed},'{col_link{main_id}}');EPJS_toggle('{col_link{colbarid}}',{is_collapsed});EPJS_toggle('{col_link{barid}}',{!is_collapsed});return false">
-            <img alt="+" src="/style/images/plus.svg" style="margin-right: 5px;" border="0">
-              <epc:print expr="col_link{render_title}"/>
-            </img>
-          </a>
-        </div>
-      </epc:if>
-      <div id="{prefix}_content" class="{content{class}} bg-white rounded">
-        <div id="{content_inner{id}}" class="p-2">
+      <div id="{prefix}_content" class="bg-white rounded {content{class}}">
+        <epc:if test="can_collapse">
+          <epc:attribute name="class">bg_white rounded ep_toggleable <epc:print expr="content{class}" /></epc:attribute>
+        </epc:if>
+        <div id="{prefix}_content_inner" class="p-2">
           <epc:comment>Add the help text if it is included, generally starts hidden (unless !no_toggle)</epc:comment>
           <epc:if test="has_help">
-            <div id="{help_item{prefix}}" class="{help_item{hide_class}}">
+            <div id="{help_item{prefix}}" class="ep_toggleable {help_item{hide_class}}">
               <div id="{help_item{prefix}}_inner" class="p-2 alert alert-info">
                 <epc:print expr="help_item{render_help}"/>
               </div>

--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -786,7 +786,7 @@
   <epp:phrase id="view:EPrints/Repository:render_row_with_help">
     <epc:choose>
       <epc:when test="has_help">
-        <div id="{help_prefix}" class="{if (has_toggle, 'd-none-not-important')}">
+        <div id="{help_prefix}" class="{if (has_toggle, 'd-none-not-important')} ep_toggleable">
           <div id="{help_prefix}_inner" class="alert alert-primary d-flex align-items-center mb-1 mt-2" role="definition" aria-labelledby="{prefix}_label">
             <epc:print expr="help"/>
           </div>
@@ -803,16 +803,11 @@
       <epc:choose>
         <epc:when test="has_toggle">
           <div class="input-group-text ms-auto">
-            <div class="ep_sr_show_help ep_only_js" id="{help_prefix}_show">
-              <a onclick="EPJS_toggleSlide('{help_prefix}',false,'block');EPJS_toggle('{help_prefix}_hide',false,'block');EPJS_toggle('{help_prefix}_show',true,'block');return false" href="#">
-                <img alt="{string_phrase(&quot;lib/session:show_help_alt&quot;)}" title="{string_phrase(&quot;lib/session:show_help_title&quot;)}" src="{string_phrase(&quot;lib/session:show_help_src&quot;)}"/>
-              </a>
-            </div>
-            <div class="ep_sr_hide_help ep_hide" id="{help_prefix}_hide">
-              <a onclick="EPJS_toggleSlide('{help_prefix}',false,'block');EPJS_toggle('{help_prefix}_hide',false,'block');EPJS_toggle('{help_prefix}_show',true,'block');return false" href="#">
-                <img alt="{string_phrase(&quot;lib/session:hide_help_alt&quot;)}" title="{string_phrase(&quot;lib/session:hide_help_title&quot;)}" src="{string_phrase(&quot;lib/session:hide_help_src&quot;)}"/>
-              </a>
-            </div>
+            <label class="ep_styled_checkbox">
+              <input type="checkbox" id="{help_prefix}_checkbox" onclick="EPJS_checkboxSlide('{help_prefix}');" />
+              <img class="ep_unchecked" src="/style/images/help.svg" alt="?" />
+              <img class="ep_checked" src="/style/images/minus.svg" alt="-" />
+            </label>
           </div>
         </epc:when>
         <epc:otherwise>

--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -1302,22 +1302,21 @@
         </div>
       </div>
       <div class="ep_upload_doc_expansion_bar ep_only_js p-2 mt-2 border-top">
-        <a class="d-flex text-black" onclick="EPJS_toggleSlideScroll('{doc_prefix}_opts',{if(hide, 'false', 'true')},'{doc_prefix}_block');EPJS_toggle('{doc_prefix}_opts_hide',{if(hide, 'false', 'true')},'block');EPJS_toggle('{doc_prefix}_opts_show',{if (hide, 'true','false')},'block');return false">
-          <div id="{doc_prefix}_opts_show" class="ep_update_doc_options ms-auto {if (hide, '','ep_hide')}">
-            <label for="{doc_prefix}_opts_show" class="p-1">
-              <epc:print expr="show_label"/>
-            </label>
-            <input class="align-middle ms-1" type="image" src="{imagesurl}/style/images/plus.svg" alt="+" id="{doc_prefix}_opts_show"/>
-          </div>
-          <div id="{doc_prefix}_opts_hide" class="ep_update_doc_options ms-auto {if (hide, 'ep_hide', '')}">
-            <label for="{doc_prefix}_opts_hide">
-              <epc:print expr="hide_label"/>
-            </label>
-            <input class="align-middle ms-1" type="image" src="{imagesurl}/style/images/minus.svg" alt="-" id="{doc_prefix}_opts_hide"/>
-          </div>
-        </a>
+        <div class="d-flex">
+          <label class="ep_styled_checkbox ms-auto">
+            <input type="checkbox" id="{doc_prefix}_opts_checkbox" onclick="EPJS_checkboxSlide('{doc_prefix}_opts');">
+              <epc:if test="!hide"><epc:attribute name="checked">checked</epc:attribute></epc:if>
+            </input>
+
+            <span class="ep_unchecked align-middle"><epc:print expr="show_label"/></span>
+            <img class="ep_unchecked ms-1" src="/style/images/plus.svg" title="Show options" alt="+" />
+
+            <span class="ep_checked align-middle"><epc:print expr="hide_label"/></span>
+            <img class="ep_checked ms-1" src="/style/images/minus.svg" title="Hide options" alt="-" />
+          </label>
+        </div>
       </div>
-      <div class="ep_upload_doc_content {if (hide, 'ep_no_js', '')}" id="{doc_prefix}_opts">
+      <div class="ep_upload_doc_content ep_toggleable {if (hide, 'ep_no_js', '')}" id="{doc_prefix}_opts">
         <div class="" id="{doc_prefix}_opts_inner">
           <epc:print expr="doc_metadata"/>
         </div>

--- a/lib/static/javascript/auto/50_toggle.js
+++ b/lib/static/javascript/auto/50_toggle.js
@@ -1,4 +1,59 @@
 /**
+ * EPJS_checkboxSlide(element_id, checkbox_id = element_id + '_checkbox')
+ *
+ * Slides dropdowns open and closed as with `EPJS_toggleSlide` and
+ * `EPJS_toggleSlideScroll` but with much less javascript.
+ *
+ * This should be set up in the `on_click` of a checkbox (`checkbox_id`)
+ * controlling a div (`element_id`) with the class `ep_toggleable` that
+ * contains another div (`element_id + '_inner'`).
+ */
+const EPJS_checkboxSlide = (element_id, checkbox_id) => {
+	const element = document.getElementById(element_id);
+	const inner = document.getElementById(element_id + '_inner');
+
+	checkbox_id ||= element_id + '_checkbox';
+	const checkbox = document.getElementById(checkbox_id);
+
+	if (checkbox.checked) {
+		// Make sure the element is visible and has a height of 0 (otherwise it
+		// may not expand properly).
+		element.style.display = 'block';
+		element.style.height = '0px';
+
+		// Wait for 0ms so that it happens on the next event trigger, allowing
+		// the `height = '0px'` from above to engage, if you set the height
+		// twice within the same tick it will only listen to the second set so
+		// won't do the animated expand.
+		setTimeout(() => {
+			// If reduced motion is set it won't do the transition so
+			// `transitionend` will never be triggered.
+			if (matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+				element.style.height = outerHeight(inner) + 'px';
+				// Once the transition ends we set its height to `auto` so that
+				// it can contain things like the help box expanding in a
+				// collapsible element.
+				element.addEventListener('transitionend', (ev) => {
+					// We check that the element has size to ensure another
+					// transition wasn't triggered midway through.
+					if (element.offsetHeight != 0) {
+						element.style.height = 'auto';
+					}
+				}, {once: true});
+			} else {
+				element.style.height = 'auto';
+			}
+		}, 0);
+	} else {
+		element.style.height = outerHeight(inner) + 'px';
+		// As above we have to wait for 0ms to ensure the above set applies.
+		setTimeout(() => {
+			element.style.height = '0px';
+		}, 0);
+	}
+};
+
+/**
  * EPJS_toggle_aux helper functions
  */
 const EPJS_toggleSlide = ( element_id, start_visible ) => EPJS_toggleSlide_aux( element_id, start_visible, null );

--- a/lib/static/style/auto/general.css
+++ b/lib/static/style/auto/general.css
@@ -234,3 +234,8 @@ div.ep_toggleable {
 	display: none;
 }
 
+/* Hide help buttons on collapsed components */
+div.ep_sr_title:has(label.ep_styled_checkbox > input:not(:checked)) ~ div.ep_only_js {
+	display: none;
+}
+

--- a/lib/static/style/auto/general.css
+++ b/lib/static/style/auto/general.css
@@ -203,3 +203,34 @@ div.ep_table {
 	padding-top: 2em;
 	text-align: center;
 }
+
+@media (prefers-reduced-motion: no-preference) {
+	div.ep_toggleable {
+		transition: height .3s;
+	}
+}
+
+div.ep_toggleable {
+	overflow: hidden;
+}
+
+.ep_styled_checkbox {
+	cursor: pointer;
+}
+.ep_styled_checkbox img {
+	margin-right: 6px;
+}
+
+.ep_styled_checkbox input {
+	display: none;
+}
+.ep_styled_checkbox .ep_checked {
+	display: none;
+}
+.ep_styled_checkbox input:checked ~ .ep_checked {
+	display: inline;
+}
+.ep_styled_checkbox input:checked ~ .ep_unchecked {
+	display: none;
+}
+


### PR DESCRIPTION
This switches expanding help sections (both for a component and inside the component), collapsible elements and `Document` 'Show details' to use a CSS transition rather than the rather awkward `EPJS_toggleSlideScroll` and its `setInterval` `height` loop.

This is primarily useful because it is simpler and makes the templates a little easier to read but it also made it easy to add support for things like `prefers-reduced-motion` (see eprints/latest_additions#18). Sadly this does need some javascript to run (because you can't expand to and from `height: auto`) however it is doing much less than it used to (only runs at the start and end of the transition).

I would have liked to replace all uses of `EPJS_toggleSlideScroll` so that it could be removed along with the infrastructure that exists only for it however it is currently still used by `ajax/subject_input` (and `Field/AjaxSubject`) which I'm not sure what they do (or how to test) and `EPrints/Box` which doesn't appear to show up anywhere in core but is used by some EPMs? As I couldn't find an easy way to test these I haven't removed `SlideScroll` as the conversion to `EPJS_checkboxSlide` is not always super easy so I would be wary of messing it up.

This does use a 'Baseline 2023' CSS feature (`:has`) however if you happen to be using an old browser that doesn't have this it will just show the help button while a collapsible component is collapsed which isn't the end of the world.