### PR TITLE
Implements #237 by adding replace_config MetaField property

### DIFF
--- a/perl_lib/EPrints/DataSet.pm
+++ b/perl_lib/EPrints/DataSet.pm
@@ -629,15 +629,30 @@ sub register_field
 	if( exists $self->{field_index}->{$fieldname} )
 	{
 		my $old_field = $self->{field_index}->{$fieldname};
-		if(
+		if ( $old_field->property( "provenance" ) eq "config" )
+		{
+			if ( !$field->property( "replace_config" ) )
+			{
+				EPrints->abort( "Duplicate field name encountered in configuration without 'replace_config' property: ".$self->base_id.".".$fieldname );
+			}
+		}
+		elsif(
 			$system ||
 			$old_field->property( "provenance" ) ne "core" ||
 			!$field->property( "replace_core" )
-		  )
+		)
 		{
 			EPrints->abort( "Duplicate field name encountered: ".$self->base_id.".".$fieldname );
 		}
 		$self->unregister_field( $old_field );
+	}
+	elsif( $field->property( "replace_config" ) )
+	{
+		$self->{repository}->log( "Initial field configuration contains 'replace_config' property: ".$self->base_id.".".$fieldname );
+	}
+	elsif( $field->property( "replace_core" ) )
+	{
+		$self->{repository}->log( "Initial field configuration contains 'replace_core' property: ".$self->base_id.".".$fieldname );
 	}
 
 	push @{$self->{fields}}, $field;

--- a/perl_lib/EPrints/MetaField.pm
+++ b/perl_lib/EPrints/MetaField.pm
@@ -67,6 +67,10 @@ Indicates where the field was initialised from. "core" fields are defined in L<D
 
 Normally any attempt to define two fields with the same name will fail. However, you can replace a core system field by specifying the "replace_core" property. This should be used very carefully!
 
+=item replace_config => 0
+
+This is similar to C<replace_core> but is only applicable to fields that were defined earlier in configuration rather than in a core code file (e.g. C<EPrints::DataObj::...>. This should still be used carefully but its potential to be dangerous is less.
+
 =back
 
 =end InternalDoc
@@ -2546,6 +2550,7 @@ sub get_property_defaults
 	return (
 		provenance => EP_PROPERTY_FROM_CONFIG,
 		replace_core => EP_PROPERTY_FALSE,
+		replace_config => EP_PROPERTY_FALSE,
 		allow_null 	=> EP_PROPERTY_TRUE,
 		browse_link 	=> EP_PROPERTY_UNDEF,
 		can_clone 	=> EP_PROPERTY_TRUE,


### PR DESCRIPTION
As well as adding this extra property it as some helpful logging to warn bad use of 'replace_core'.