### PR TITLE
Convert `EPrints::Box` to expand with CSS transitions

### DIFF
--- a/perl_lib/EPrints/Box.pm
+++ b/perl_lib/EPrints/Box.pm
@@ -121,7 +121,7 @@ sub EPrints::Box::render
 		id => "${contentid}_checkbox",
 		onclick => "EPJS_checkboxSlide('${contentid}')"
 	) );
-	$checkbox_label->appendChild( $session->make_element( 'img', class => 'ep_unchecked', src => $options{show_icon_url}, alt => '?' ) );
+	$checkbox_label->appendChild( $session->make_element( 'img', class => 'ep_unchecked', src => $options{show_icon_url}, alt => '+' ) );
 	$checkbox_label->appendChild( $session->make_element( 'img', class => 'ep_checked', src => $options{hide_icon_url}, alt => '-' ) );
 	my $checkbox_span = $checkbox_label->appendChild( $session->make_element( 'span', class => 'align-middle' ) );
 	$checkbox_span->appendChild( $session->clone_for_me( $options{title}, 1 ) );


### PR DESCRIPTION
This was introduced in #232 however that left `EPrints::Box` and `ajax/subject_input` alone as I couldn't find an easy way to test them.

I have since become aware that the Help tab (for example on the 'Manage Deposits' page) is a box (added via `epv:box`) so have switched this over to use `checkboxSlide`.

As with #232, this improves the sanity of the HTML by only hiding and showing the '?' and '-' icons and doesn't have to repeatedly set height in a loop with javascript.

The only thing still using `EPJS_toggleSlideScroll` in core is `ajax/subject_input` however there is no great reason to switch that over as it should be left for backwards compatibility anyway.