### PR TITLE
Match the 'Edit page' hyperlink to look like the others

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Admin/Config/Edit/XPage.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Admin/Config/Edit/XPage.pm
@@ -61,11 +61,9 @@ sub render_action_link
 		configfile => $conffile,
 	);
 
-	$opts{class} = "nav-link text-black" if not defined $opts{class};
-	my $link = $self->{session}->render_link( $uri, undef, %opts );
-	$link->appendChild( $self->{session}->html_phrase( "lib/session:edit_page" ) );
-
-	return $link;
+	$opts{uri} = $uri;
+	$opts{link_title} = $self->{session}->html_phrase( "lib/session:edit_page" );
+	return $self->SUPER::render_action_link( %opts );
 }
 
 1;


### PR DESCRIPTION
As this button only shows up conditionally (you need to have an `index.xpage` file copied into your archive) it was missed from the original set of changes for menu buttons.

This changes the class to the same as the other buttons in that menu, making it centered and black.

Fixes #235.