### PR TITLE
Issue #53: Removing eval from Javascript

### DIFF
--- a/lib/static/javascript/auto/50_tabs.js
+++ b/lib/static/javascript/auto/50_tabs.js
@@ -25,7 +25,6 @@ const ep_showTab = ( baseid, tabid, expensive ) => {
 				panel.loaded = 1;
 			},
 			method: "get",
-			evalScripts: true,
 			parametersString: 'ajax=1&' + link[1]
 		});
 	}


### PR DESCRIPTION
I can find no remaining usages of eval in core js, nor anywhere which still sets HTTP header 'unsafe-eval'.

Panels: evalScripts option no longer respected in our ajax function, and removing as an abundance of caution when reviewing for remaining use of eval in JS

Probably worth keeping the issue open in case anything slips in as we merge more ingredients into core.