### PR TITLE
#142: Configure admin only search pages back to paginated

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Staff/IssueSearch.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Staff/IssueSearch.pm
@@ -24,6 +24,8 @@ sub new
 		},
 	];
 
+    $self->{search_result_style} = 'paginate';
+
 	return $self;
 }
 

--- a/perl_lib/EPrints/Plugin/Screen/Staff/OrganisationSearch.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Staff/OrganisationSearch.pm
@@ -24,6 +24,8 @@ sub new
 		},
 	];
 
+    $self->{search_result_style} = 'paginate';
+
 	return $self;
 }
 

--- a/perl_lib/EPrints/Plugin/Screen/Staff/PersonSearch.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Staff/PersonSearch.pm
@@ -24,6 +24,8 @@ sub new
 		},
 	];
 
+    $self->{search_result_style} = 'paginate';
+
 	return $self;
 }
 

--- a/perl_lib/EPrints/Plugin/Screen/Staff/UserSearch.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Staff/UserSearch.pm
@@ -24,6 +24,8 @@ sub new
 		},
 	];
 
+    $self->{search_result_style} = 'paginate';
+
 	return $self;
 }
 


### PR DESCRIPTION
The default which was a broken infinite scroll, I'm not sure we really need infinite scroll on these admin only pages, so I've configured them to be paginated, which works.

#142 