### PR TITLE
Adds names and ids render functions for entities (#264)

### DIFF
--- a/lib/cfg.d/entities.pl
+++ b/lib/cfg.d/entities.pl
@@ -34,3 +34,107 @@ $c->{entities}->{person}->{human_deserialise_name} = sub
 
     return $name;
 };
+
+
+$c->{render_entity_names} = sub
+{
+	my( $session, $field, $names ) = @_;
+
+	my $frag = $session->make_doc_fragment();
+	my $ul = $session->make_element( 'ul', class => 'ep_entity_names_list' );
+
+	my $name_field;
+	my $from_field;
+	my $to_field;
+	my $lang_field;
+
+	foreach my $inner_field_config ( @{$field->get_property( 'fields_cache' )}, $field->extra_subfields )
+	{
+		next unless $inner_field_config->{name};
+		my $inner_field = $field->dataset->get_field( $inner_field_config->{name} );
+		if ( $inner_field->get_property( 'sub_name' ) eq "name" )
+		{
+			$name_field = $inner_field;
+		}
+		elsif ( $inner_field->get_property( 'sub_name' ) eq "from" )
+		{
+			$from_field = $inner_field;
+		}
+		elsif ( $inner_field->get_property( 'sub_name' ) eq "to" )
+        {
+			$to_field = $inner_field;
+        }
+		elsif ( $inner_field->get_property( 'sub_name' ) eq "lang" )
+        {
+            $lang_field = $inner_field;
+        }
+	}
+
+	foreach my $name ( @$names )
+	{
+		my $li = $session->make_element( 'li' );
+
+		$li->appendChild( $name_field->render_single_value( $session, $name->{name} ) );
+		my $daterange = "";
+		if ( $name->{from} )
+		{
+			$daterange = EPrints::Utils::tree_to_utf8( $from_field->render_single_value( $session, $name->{from} ) );
+		}
+		if ( $name->{to} )
+		{
+			$daterange .= " " if $name->{from};
+			$daterange .= "- " . EPrints::Utils::tree_to_utf8( $to_field->render_single_value( $session, $name->{to} ) );
+		}
+		elsif ( $name->{from} )
+		{
+			$daterange .= " -";
+		}
+		if ( $daterange )
+		{
+			$li->appendChild( $session->make_text( ' (' . $daterange . ')' ) );
+		}
+		if ( $name->{lang} )
+		{
+			$li->appendChild( $session->make_text( ' [' . $session->render_language_name( $name->{lang} ) . ']' ) );
+		}
+		$ul->appendChild( $li );
+	}
+
+	$frag->appendChild( $ul );
+	return $frag;
+};
+
+$c->{render_entity_ids} = sub
+{
+    my( $session, $field, $ids ) = @_;
+
+    my $frag = $session->make_doc_fragment();
+    my $dl = $session->make_element( 'dl', class => 'ep_entity_ids_list' );
+
+    my $id_field;
+    my $id_type_field;
+    foreach my $inner_field_config ( @{$field->get_property( 'fields_cache' )} )
+    {
+		my $inner_field = $field->dataset->get_field( $inner_field_config->{name} );
+        if ( $inner_field->get_property( 'sub_name' ) eq "id" )
+        {
+            $id_field = $inner_field;
+			last;
+        }
+    }
+
+    foreach my $id ( @$ids )
+    {
+        my $dt = $session->make_element( 'dt' );
+		$dt->appendChild( $session->html_phrase( $field->dataset->id . '_id_type_typename_'.$id->{id_type} ) );
+		$dl->appendChild( $dt );
+
+		my $dd =  $session->make_element( 'dd' );
+		$dd->appendChild( $id_field->render_single_value( $session, $id->{id} ) );
+		$dl->appendChild( $dd );
+
+    }
+
+    $frag->appendChild( $dl );
+    return $frag;
+};

--- a/lib/cfg.d/organisation_render.pl
+++ b/lib/cfg.d/organisation_render.pl
@@ -1,9 +1,9 @@
 $c->{organisation_page_metadata} = [qw/
-    names
-    ids
+	name
+	names
+	ids
 	address
 	country
-    lastmod
 /];
 
 ######################################################################

--- a/lib/cfg.d/person_render.pl
+++ b/lib/cfg.d/person_render.pl
@@ -1,6 +1,7 @@
 $c->{person_page_metadata} = [qw/
-    name
-    ids
+	name
+	names
+	ids
 	dept
 	organisation
 	address

--- a/lib/citations/organisation/entity_page.xml
+++ b/lib/citations/organisation/entity_page.xml
@@ -6,11 +6,7 @@
 
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
 
-  <p style="margin-bottom: 1em">
-    <epc:print expr="$item.citation('default')" />
-  </p>
-
-  <table style="margin-bottom: 1em; margin-top: 1em;" cellpadding="3">
+  <table class="ep_summary_table" id="ep_organisation_summary_table">
     <epc:comment> 
        The below block loops over a list of field names taken from organisation_render.pl
        Edit the list of metadata to show in the entity page table in organisation_render.pl
@@ -18,21 +14,21 @@
     <epc:foreach expr="$config{organisation_page_metadata}" iterator="fieldname">
       <epc:if test="is_set($item.property($fieldname))">
         <tr>
-          <th align="right"><epc:phrase ref="organisation_fieldname_{$fieldname}" />:</th>
-          <td valign="top"><epc:print expr="$item.property($fieldname)" /></td>
+          <th><epc:phrase ref="organisation_fieldname_{$fieldname}" />:</th>
+          <td><epc:print expr="$item.property($fieldname)" /></td>
         </tr>
       </epc:if>
     </epc:foreach>
     <tr>
-      <th align="right">URI:</th>
-      <td valign="top"><a href="{$item.uri()}"><epc:print expr="$item.uri()" /></a></td>
+      <th>URI:</th>
+      <td><a href="{$item.uri()}"><epc:print expr="$item.uri()" /></a></td>
     </tr>
   </table>
 
   <epc:if test="!$flags{preview}">
     <epc:phrase ref="entity_page:actions"/>
     <dl class="ep_entity_page_actions">
-    <epc:foreach expr="action_list('organisation_entity_page_actions',$item)" iterator="action">
+    <epc:foreach expr="entity_action_list('entity_page_actions',$item)" iterator="action">
       <dt><epc:print expr="$action.action_icon()" /></dt>
       <dd><epc:print expr="$action.action_title()" /></dd>
     </epc:foreach>

--- a/lib/citations/person/entity_page.xml
+++ b/lib/citations/person/entity_page.xml
@@ -6,7 +6,7 @@
 
 <cite:citation xmlns="http://www.w3.org/1999/xhtml" xmlns:epc="http://eprints.org/ep3/control" xmlns:cite="http://eprints.org/ep3/citation" >
 
-  <table style="margin-bottom: 1em; margin-top: 1em;" cellpadding="3">
+  <table class="ep_summary_table" id="ep_person_summary_table">
     <epc:comment> 
        The below block loops over a list of field names taken from person_render.pl
        Edit the list of metadata to show in the entity page table in person_render.pl
@@ -14,14 +14,14 @@
     <epc:foreach expr="$config{person_page_metadata}" iterator="fieldname">
       <epc:if test="is_set($item.property($fieldname))">
         <tr>
-          <th align="right"><epc:phrase ref="person_fieldname_{$fieldname}" />:</th>
-          <td valign="top"><epc:print expr="$item.property($fieldname)" /></td>
+          <th><epc:phrase ref="person_fieldname_{$fieldname}" />:</th>
+          <td><epc:print expr="$item.property($fieldname)" /></td>
         </tr>
       </epc:if>
     </epc:foreach>
     <tr>
-      <th align="right">URI:</th>
-      <td valign="top"><a href="{$item.uri()}"><epc:print expr="$item.uri()" /></a></td>
+      <th>URI:</th>
+      <td><a href="{$item.uri()}"><epc:print expr="$item.uri()" /></a></td>
     </tr>
   </table>
 
@@ -31,7 +31,7 @@
   <epc:if test="!$flags{preview}">
     <epc:phrase ref="entity_page:actions"/>
     <dl class="ep_entity_page_actions">
-    <epc:foreach expr="entity_action_list('eprint_entity_page_actions',$item)" iterator="action">
+    <epc:foreach expr="entity_action_list('entity_page_actions',$item)" iterator="action">
       <dt><epc:print expr="$action.action_icon()" /></dt>
       <dd><epc:print expr="$action.action_title()" /></dd>
     </epc:foreach>

--- a/lib/lang/en/phrases/system.xml
+++ b/lib/lang/en/phrases/system.xml
@@ -3395,7 +3395,7 @@ Titles and Help for the System Fields
     <epp:phrase id="person_id_type_typename_email">Email</epp:phrase>
     <epp:phrase id="person_id_type_typename_username">Username</epp:phrase>
     <epp:phrase id="person_fieldname_name">Primary Name</epp:phrase>
-    <epp:phrase id="person_fieldname_names">Names</epp:phrase>
+    <epp:phrase id="person_fieldname_names">All Names</epp:phrase>
     <epp:phrase id="person_fieldname_names_name">Name</epp:phrase>
     <epp:phrase id="person_fieldname_names_from">From</epp:phrase>
     <epp:phrase id="person_fieldname_names_to">To</epp:phrase>
@@ -3443,7 +3443,7 @@ Titles and Help for the System Fields
     <epp:phrase id="organisation_id_type_typename_url">URL</epp:phrase>
     <epp:phrase id="organisation_id_type_typename_email">Email</epp:phrase>
     <epp:phrase id="organisation_fieldname_name">Primary Name</epp:phrase>
-    <epp:phrase id="organisation_fieldname_names">Name</epp:phrase>
+    <epp:phrase id="organisation_fieldname_names">All Names</epp:phrase>
     <epp:phrase id="organisation_fieldname_names_name">Name</epp:phrase>
     <epp:phrase id="organisation_fieldname_names_from">From</epp:phrase>
     <epp:phrase id="organisation_fieldname_names_to">To</epp:phrase>

--- a/lib/static/style/auto/entities.css
+++ b/lib/static/style/auto/entities.css
@@ -20,3 +20,19 @@
     text-align: right;
 }
 
+ul.ep_entity_names_list {
+	list-style-position: inside;
+	padding-left: 0;
+}
+dl.ep_entity_ids_list {
+  display: grid;
+  grid-gap: 4px 16px;
+  grid-template-columns: max-content;
+}
+dl.ep_entity_ids_list > dt {
+  font-weight: bold;
+}
+dl.ep_entity_ids_list > dd {
+  margin: 0;
+  grid-column-start: 2;
+}

--- a/lib/static/style/auto/summary.css
+++ b/lib/static/style/auto/summary.css
@@ -69,3 +69,13 @@
 	float: left;
 	margin-left: 0.5em;
 }
+
+.ep_summary_table {
+	margin-bottom: 1em;
+	margin-top: 1em;
+}
+
+.ep_summary_table tr > th, .ep_summary_table tr > td {
+	vertical-align: top;
+	padding: 3px;
+}

--- a/perl_lib/EPrints/DataObj/Organisation.pm
+++ b/perl_lib/EPrints/DataObj/Organisation.pm
@@ -122,6 +122,7 @@ sub get_system_field_info
 			],
 			input_boxes => 1,
 			required => 1,
+			render_value => 'render_entity_ids',
 	},
 
 	{
@@ -136,8 +137,8 @@ sub get_system_field_info
 		fields=>[
 			{
 				sub_name => 'name',
-			type => 'text',
-			input_cols => 30,
+				type => 'text',
+				input_cols => 30,
 				required => 1,
 			},
 			{
@@ -151,6 +152,7 @@ sub get_system_field_info
 		],
 		multiple => 1,
 		input_boxes => 1,
+		render_value => 'render_entity_names',
 	},
 
 	{

--- a/perl_lib/EPrints/DataObj/Person.pm
+++ b/perl_lib/EPrints/DataObj/Person.pm
@@ -105,23 +105,24 @@ sub get_system_field_info
 	},
 
 
-		{
-			name => 'ids',
-			type => 'compound',
-			multiple => 1,
-			fields => [
-				{
-					sub_name => 'id',
-					type => 'id',
-				},
-				{
-					sub_name => 'id_type',
-					type => 'namedset',
-					set_name => $class->get_dataset_id . "_id_type",
-				},
-			],
-			input_boxes => 1,
-			required => 1,
+	{
+		name => 'ids',
+		type => 'compound',
+		multiple => 1,
+		fields => [
+			{
+				sub_name => 'id',
+				type => 'id',
+			},
+			{
+				sub_name => 'id_type',
+				type => 'namedset',
+				set_name => $class->get_dataset_id . "_id_type",
+			},
+		],
+		input_boxes => 1,
+		required => 1,
+		render_value => 'render_entity_ids',
 	},
 
 	{
@@ -151,6 +152,7 @@ sub get_system_field_info
 		],
 		multiple => 1,
 		input_boxes => 1,
+		render_value => 'render_entity_names',
 	},
 
 	{

--- a/perl_lib/EPrints/MetaField/Multilang.pm
+++ b/perl_lib/EPrints/MetaField/Multilang.pm
@@ -78,8 +78,9 @@ sub render_value
 {
 	my( $self, $session, $value, $alllangs, $nolink, $object ) = @_;
 
-	if( $alllangs )
+	if( $alllangs || defined $self->property( "render_value" ) )
 	{
+		$alllangs = 1;
 		return $self->SUPER::render_value( 
 				$session,$value,$alllangs,$nolink,$object);
 	}

--- a/perl_lib/EPrints/Plugin/Screen/Entity/View.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Entity/View.pm
@@ -26,7 +26,7 @@ sub new
 	{
 		push @{$self->{appears}}, 
 		{
-			place => "eprint_entity_page_actions",
+			place => "entity_page_actions",
 			position => 100,
 		},
 		{
@@ -183,11 +183,7 @@ sub render_common_action_buttons
 {
 	my( $self ) = @_;
 
-	my $frag = $self->{session}->make_doc_fragment;
-
-	$frag->appendChild( $self->render_action_list_bar( "entity_actions_bar", ['dataset, entity'] ) );
-
-	return $frag;
+	return  $self->render_action_list_bar( "entity_actions_bar", [ 'dataset', 'entity' ] );
 }
 
 


### PR DESCRIPTION
- Adds names to entity render fields lists.
- Uses class attributes so CSS can be used on entity summary tables. 
- Fixes broken link for organisation's Actions view. 
- Updates phrases for entities' names' fields.
- Also fixes multilang metafield to allow bespoke render_value functions.