### PR TITLE
#270: Restore old eprints 3.4 behaviour for paginated lists

### DIFF
--- a/ingredients/eprints_classic_style/lang/en/phrases/ep_template.xml
+++ b/ingredients/eprints_classic_style/lang/en/phrases/ep_template.xml
@@ -149,7 +149,7 @@
               </epc:param>
             </epc:phrase>
             <epc:whitespace empty="preserve"> </epc:whitespace>
-            <epc:if test="page_size != ''">
+            <epc:if test="page_size = ''">
               <epc:phrase ref="lib/searchexpression:results_page_size">
                 <epc:param name="n_10">
                   <epv:link uri="{url}&amp;{basename}page_size=10">10</epv:link>

--- a/lib/lang/en/phrases/ep_template.xml
+++ b/lib/lang/en/phrases/ep_template.xml
@@ -211,7 +211,7 @@
                 </epc:param>
               </epc:phrase>
               <epc:whitespace empty="preserve"> </epc:whitespace>
-              <epc:if test="page_size != ''">
+              <epc:if test="page_size = ''">
                 <epc:phrase ref="lib/searchexpression:results_page_size">
                   <epc:param name="n_10">
                     <epv:link uri="{url}&amp;{basename}page_size=10">10</epv:link>


### PR DESCRIPTION
The old 3.4 behaviour was to not show page size options if page_size was configured for the search. I believe this was the intent, so I've rectified it.