### PR TITLE
Excludes entity_page and summary_page citation styles from cache (#276)

### DIFF
--- a/lib/cfg.d/citationcaches.pl
+++ b/lib/cfg.d/citationcaches.pl
@@ -3,9 +3,9 @@ $c->{citation_caching}->{enabled} = 1;
 
 # CitationCache Dataset
 $c->{datasets}->{citationcache} = {
-        class => "EPrints::DataObj::CitationCache",
-        sqlname => "citationcache",
-        index => 0,
+	class => "EPrints::DataObj::CitationCache",
+	sqlname => "citationcache",
+	index => 0,
 };
 
 # Exclude specific data objects from caching
@@ -16,5 +16,7 @@ $c->{citation_caching}->{excluded_dataobjs} = [
 
 # Exclude specific citation styles from caching
 $c->{citation_caching}->{excluded_styles} = [
-        'result',
+	'entity_page',
+	'result',
+	'summary_page',
 ];

--- a/perl_lib/EPrints/DataObj.pm
+++ b/perl_lib/EPrints/DataObj.pm
@@ -1594,7 +1594,7 @@ sub render_citation
 	if ( !defined $params{no_cache} || !$params{no_cache} )
 	{
 		my @excluded_dataobjs = ( 'loginticket', 'subject' );
-		my @excluded_styles = ( 'result' );
+		my @excluded_styles = ( 'entity_page', 'result', 'summary_page' );
 		@excluded_dataobjs = @{$self->{session}->config( "citation_caching", "excluded_dataobjs" )} if defined $self->{session}->config( "citation_caching", "excluded_dataobjs" );
 		@excluded_styles = @{$self->{session}->config( "citation_caching", "excluded_styles" )} if defined $self->{session}->config( "citation_caching", "excluded_styles" );
 		$citation_caching_enabled = defined $self->{session}->config( "citation_caching", "enabled" ) && $self->{session}->config( "citation_caching", "enabled" ) && !$citation->{disable_caching} && !(grep { $self->{dataset}->confid eq $_ } @excluded_dataobjs) && !(grep { $style eq $_ } @excluded_styles);


### PR DESCRIPTION
As the entity_page citation style is basically the entity page then caching it is rather duplication and could lead to issues with pages not updating after certain config changes are made.  

This is much the same for abstract/summary pages but they only have a (largish) part of the page contents that is controlled by a citation.  However, there is little benefit to caching this as the page is cached.  Its only if you are viewing in the preview tab would this lead to any increased load.