### PR TITLE
Fix spinner when loading an autocomplete field

### DIFF
--- a/lib/static/javascript/auto/70_autocomplete.js
+++ b/lib/static/javascript/auto/70_autocomplete.js
@@ -7,7 +7,7 @@ const ep_autocompleter = (element, target, url, basenames, width_of_these, field
 			let target_elem = document.getElementById(target)
 			target_elem.style.position = 'absolute';
 			target_elem.style.width = w + 'px';
-
+			document.getElementById(target + "_loading").style.display = null;
 			document.getElementById(target + "_loading").style.width = w + 'px';
 
 			let params = fields_to_send.reduce((acc, field_id) => {
@@ -20,6 +20,7 @@ const ep_autocompleter = (element, target, url, basenames, width_of_these, field
 		onShow: (element) => {
 			let target_elem = element.parentNode.parentNode.querySelector('.ep_drop_target')
 			appearEffect(target_elem, 150, 15)
+			document.getElementById(target + "_loading").style.display = 'none';
 		},
 		updateElement: (selected) => {
 			var ul = selected.querySelectorAll('ul')[0];


### PR DESCRIPTION
Richard has fixed this in Composer, porting it back to EPrints 3.5.

There wasn't an issue for it, but it's a two line change and Richard's already done the work.

I added a sleep in `cgi/users/lookup/contributor` to simulate a slow response.