### PR TITLE
Fixed syntax error, missing semicolon

### DIFF
--- a/bin/generate_static
+++ b/bin/generate_static
@@ -126,7 +126,7 @@ use Pod::Usage;
 my $version = 0;
 my $verbose = 0;
 my $quiet = 0;
-my $force = 0
+my $force = 0;
 my $prune = 0;
 my $reload = 0;
 my $help = 0;


### PR DESCRIPTION
Missing semicolon in generate static