### PR TITLE
Document upload file editor layout issues (#349)

### DIFF
--- a/lib/static/javascript/auto/40_lightbox.js
+++ b/lib/static/javascript/auto/40_lightbox.js
@@ -65,7 +65,7 @@ class Lightbox {
 	// Show the lightbox for the `index`th element from `group`
 	show(group, index) {
 		const overlay = Lightbox.overlayElement;
-		overlay.style.width = Math.max(document.body.scrollWidth, self.innerWidth) + 'px';
+		//overlay.style.width = Math.max(document.body.scrollWidth, self.innerWidth) + 'px';
 		overlay.style.height = Math.max(document.body.scrollHeight, self.innerHeight) + 'px';
 
 		// Fade from 0.0 to 0.8 over the course of 200ms

--- a/lib/static/javascript/auto/89_component_documents.js
+++ b/lib/static/javascript/auto/89_component_documents.js
@@ -143,7 +143,7 @@ class Component_Documents {
 
 		document.querySelectorAll('select, object, embed').forEach(function(node){ node.style.visibility = 'hidden' });
 
-		this.overlay.style.width = document.body.scrollWidth + 'px';
+		//this.overlay.style.width = document.body.scrollWidth + 'px';
 		this.overlay.style.height = document.body.scrollHeight + 'px';
 
 		appearEffect(this.overlay, 150, 15, 0.8)

--- a/lib/static/style/auto/general.css
+++ b/lib/static/style/auto/general.css
@@ -159,7 +159,7 @@ th.ep_title_row {
 	margin: 2px;
 	min-width:66px;
 	min-height:50px;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 }

--- a/lib/static/style/auto/upload.css
+++ b/lib/static/style/auto/upload.css
@@ -11,3 +11,7 @@
     justify-content: center;
     cursor: pointer;
 }
+
+.ep_upload_file_table .ep_table_data, .ep_upload_file_table .ep_table_header {
+	word-break: break-all;
+}


### PR DESCRIPTION
Fixes:

1. The semi transparent background when using lightbox or the file editor for a document upload is only set to the initial width of the page therefore if you maximise the window whilst you have this open you will see a none overlayed column on the RHS of the page.
2. The table for the file editor on the document upload often expands beyond the right of the white dialogue panel.
3. The border round thumbnails on the file upload stage expands to the width of the text below (a problem if the filename is very long) rather than creating a roughly even margin around the icon.
