### PR TITLE
Issue #355: tidy up labels. …

### DIFF
--- a/perl_lib/EPrints/MetaField/Boolean.pm
+++ b/perl_lib/EPrints/MetaField/Boolean.pm
@@ -137,7 +137,8 @@ sub get_basic_input_elements
 			onclick => $onclick,
 			class => join(" ", @classes),
 			value => "TRUE",
-			'aria-labelledby' => $basename . "_true_label" );
+			# no aria-labelledby as this is labeled by a <label for...> block, added below
+			 );
 		$inputs->{false} = $session->render_noenter_input_field(
 			type => "radio",
 			checked=>( defined $value && $value eq 
@@ -148,7 +149,8 @@ sub get_basic_input_elements
 			onclick => $onclick,
 			class => join(" ", @classes),
 			value => "FALSE",
-			'aria-labelledby' => $basename . "_false_label" );
+			# no aria-labelledby as this is labeled by a <label for...> block, added below
+			 );
 		if( !$self->get_property( "required" ) )
                 {
                         $inputs->{unspecified} = $session->render_noenter_input_field(
@@ -158,8 +160,7 @@ sub get_basic_input_elements
                                 id => $basename . "_unspecified",
                                 class => join(" ", @classes),
                                 onclick => $onclick,
-                                value => "",
-				'aria-labelledby' => $basename . "_unspecified_label" )
+                                value => "")
 		}
 
 		my @options = qw/ true false /;

--- a/perl_lib/EPrints/Plugin/InputForm/Component/Field/Subject.pm
+++ b/perl_lib/EPrints/Plugin/InputForm/Component/Field/Subject.pm
@@ -242,13 +242,14 @@ sub _render_node
 	}
 	# can be selected
 	elsif( $subject->can_post )
-	{
-		$frag->appendChild( $session->render_button(
+	{	
+		my $label = $frag->appendChild( $session->xml->create_data_element("label") );
+		$label->appendChild( $session->render_button(
 			class=> "ep_subjectinput_add_button",
 			name => join('_', '_internal', $self->{prefix}, $subject->id, 'add'),
 			value => $self->phrase( "add" ) ) );
-		$frag->appendChild( $session->make_text( " " ) );
-		$frag->appendChild( $title );
+		$label->appendChild( $session->make_text( " " ) );
+		$label->appendChild( $title );
 	}
 	else
 	{


### PR DESCRIPTION
Primarily so automated tests can click things more easily, but generally because if we're going to have labels they might as well be correct.