### PR TITLE
Implements #363, preserving screen tab on screen reload

### DIFF
--- a/lib/static/javascript/auto/50_tabs.js
+++ b/lib/static/javascript/auto/50_tabs.js
@@ -32,3 +32,18 @@ const ep_showTab = ( baseid, tabid, expensive ) => {
 	return false;
 };
 
+// Sets the tabs_current value, to be picked up in XHTML.pm/tabs
+window.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll(".ep_tab_bar > li").forEach((tabButton) => {
+        tabButton.addEventListener("click", () => {
+            // Pull out the name of the tab row, and the tab ID of the button just clicked
+            let tabRowName = tabButton.getAttribute("id").split("_").slice(0,-2).join("_");
+            let currentTabID = tabButton.getAttribute("id").split("_").at(-1);
+
+            // Put the ID of the current tab in the search params
+            let searchParams = new URLSearchParams(window.location.search);
+            searchParams.set(`${tabRowName}_current`, currentTabID)
+            history.replaceState(window.title, window.title, window.location.href.split('?')[0] + '?' + searchParams.toString())
+        })
+    })
+})


### PR DESCRIPTION
the url parameter `{tabid}_tabs_current` is already used in XHTML.pm/tabs to select a specific tab on page load, this just sets it when a tab is clicked, preserving the current tab on screen reload.