### PR TITLE
#351: update readme to reflect that EPrints is actually LGPL, not GPL

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -68,14 +68,14 @@ EPrints can be contacted in the real world at
 Copyright 2000-2022 University of Southampton.
 
 EPrints is free software: you can redistribute it and/or modify it
-under the terms of the GNU General Public License as published
+under the terms of the GNU Lesser General Public License as published
 by the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 EPrints is distributed in the hope that it will be useful, but WITHOUT
 ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
 License for more details.
 
-You should have received a copy of the GNU General Public License
+You should have received a copy of the GNU Lesser General Public License
 along with EPrints.  If not, see L<https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Don't think there's anything more to this ticket, just a slight adjustment to the readme to reflect reality.

closes #351 
