### PR TITLE
closes 366 by using Screen_EPrint_UploadMethod_File method

### DIFF
--- a/lib/static/javascript/auto/88_uploadmethod_file.js
+++ b/lib/static/javascript/auto/88_uploadmethod_file.js
@@ -217,21 +217,10 @@ const UploadMethod_process_file = (form, formData, prefix, component, fileLabel)
 
 const UploadMethod_file_change = (input, component, prefix) => {
 	if (input.value) {
+		const uploadObj = new Screen_EPrint_UploadMethod_File(prefix, component, input);
 
-		const form = input.closest('form');
-		const formData = new FormData(form);
-		const fileLabel = input.value.replace(/.*[^\\/][\\/]/, '');
+		uploadObj.handleFiles(input.files);
 
-		var filesizes_ok = true;
-		for (var i = 0; i < input.files.length; i++)
-		{
-			filesizes_ok = UploadMethod_check_filesize( input.files[i] );
-			if ( ! filesizes_ok ) { break }
-		}
-
-		if ( filesizes_ok ) {
-			UploadMethod_process_file(form, formData, prefix, component, fileLabel);
-		}
 	}
 }
 


### PR DESCRIPTION
closes #366 by using the handleFiles method of the Screen_EPrint_UploadMethod_File object, previously only used for file drag and drops