### PR TITLE
Fixes issues with unit tests reporting unstable on Jenkins

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/AbstractSearch.pm
+++ b/perl_lib/EPrints/Plugin/Screen/AbstractSearch.pm
@@ -695,7 +695,7 @@ sub render_results
 
 	my $page = $self->{session}->make_doc_fragment;
 	$page->appendChild( $self->render_results_intro );
-	if ( $self->{search_result_style} eq "paginate" )
+	if ( defined $self->{search_result_style} && $self->{search_result_style} eq "paginate" )
 	{
 		$page->appendChild( 
 			EPrints::Paginate->paginate_list( 

--- a/perl_lib/EPrints/Plugin/Screen/EPrint.pm
+++ b/perl_lib/EPrints/Plugin/Screen/EPrint.pm
@@ -62,7 +62,7 @@ sub allow
 {
 	my( $self, $priv ) = @_;
 
-	unless ( defined $self->{processor}->{eprint} )
+	if ( ! defined $self->{processor}->{eprint} && $self->{session}->request && $self->{session}->request->can( 'pnotes' ) )
 	{
 		$self->{processor}->{eprint} = $self->{session}->request->pnotes( 'eprint' );
 	}


### PR DESCRIPTION
1. search_results_style for abstract search is tested to see if it is 'paginate' but string comparison errors if undefined.
2. Can retrieve pnotes from request if code is instantiated from a unit test rather than a web request.