### PR TITLE
Consistent breadcrumbs and use of templates

### DIFF
--- a/lib/lang/en/static/information.xpage
+++ b/lib/lang/en/static/information.xpage
@@ -1,7 +1,6 @@
 <?xml version="1.0" standalone="no" ?>
 <!DOCTYPE page SYSTEM "entities.dtd" >
 <xpage:page xmlns="http://www.w3.org/1999/xhtml" xmlns:xpage="http://eprints.org/ep3/xpage" xmlns:epc="http://eprints.org/ep3/control">
-<xpage:template>default_internal</xpage:template>
 <xpage:title>About the Repository</xpage:title>
 <xpage:body>
 

--- a/lib/templates/default.xml
+++ b/lib/templates/default.xml
@@ -87,13 +87,7 @@
                     <path d="M8.707 1.5a1 1 0 0 0-1.414 0L.646 8.146a.5.5 0 0 0 .708.708L8 2.207l6.646 6.647a.5.5 0 0 0 .708-.708L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293z"/>
                     <path d="m8 3.293 6 6V13.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 13.5V9.293l6-6Z"/>
                   </svg>
-                  <span class="sr-only">Home</span>
-                </a>
-              </div>
-              <div class="me-3">
-                <a href="/" class="text-black text-decoration-none">
-                  <epc:phrase ref="archive_name"/>
-                </a>
+                  <span class="ms-xxl-3 text-black"><epc:phrase ref="archive_name"/></span>
               </div>
               <div class="me-3">
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">

--- a/lib/templates/default_internal.xml
+++ b/lib/templates/default_internal.xml
@@ -119,11 +119,7 @@
                     <path d="M8.707 1.5a1 1 0 0 0-1.414 0L.646 8.146a.5.5 0 0 0 .708.708L8 2.207l6.646 6.647a.5.5 0 0 0 .708-.708L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293z"/>
                     <path d="m8 3.293 6 6V13.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 13.5V9.293l6-6Z"/>
                   </svg>
-                </a>
-              </div>
-              <div class="me-3">
-                <a href="/" class="text-black text-decoration-none">
-                  <epc:phrase ref="archive_name"/>
+                  <span class="ms-xxl-3 text-black"><epc:phrase ref="archive_name"/></span>
                 </a>
               </div>
               <div class="me-3">

--- a/lib/templates/search.xml
+++ b/lib/templates/search.xml
@@ -87,12 +87,7 @@
                     <path d="M8.707 1.5a1 1 0 0 0-1.414 0L.646 8.146a.5.5 0 0 0 .708.708L8 2.207l6.646 6.647a.5.5 0 0 0 .708-.708L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293z"/>
                     <path d="m8 3.293 6 6V13.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 13.5V9.293l6-6Z"/>
                   </svg>
-                  <span class="sr-only">Home</span>
-                </a>
-              </div>
-              <div class="me-3">
-                <a href="/" class="text-black text-decoration-none">
-                  <epc:phrase ref="archive_name"/>
+                  <span class="ms-xxl-3 text-black"><epc:phrase ref="archive_name"/></span>
                 </a>
               </div>
               <div class="me-3">


### PR DESCRIPTION
- Makes sure templates are consistent for breadcrumbs between each other and flavours.
- Removes issue with redundant link where / link appears twice next to each other.
- Changes "About this Repository" page to use default rather than default_internal template.