### PR TITLE
Add rule to prevent flickering in dropdown on mouse leave/return

### DIFF
--- a/lib/static/style/auto/bootstrap_custom.css
+++ b/lib/static/style/auto/bootstrap_custom.css
@@ -15,3 +15,8 @@ input { border: var(--bs-border-width) solid var(--bs-border-color); }
 
 .input-group select { border-color: #ccc; }
 
+select.btn:open {
+    color: var(--bs-btn-active-color);
+    background-color: var(--bs-btn-active-bg);
+    border-color: var(--bs-btn-active-border-color);
+}


### PR DESCRIPTION
Adds a CSS rule to prevent flickering of open dropdown menus, resolving #386 