### PR TITLE
Adds facets to search config

### DIFF
--- a/perl_lib/EPrints/Plugin/Screen/Search.pm
+++ b/perl_lib/EPrints/Plugin/Screen/Search.pm
@@ -37,32 +37,12 @@ sub get_facet_config
 {
 	my( $self ) = @_;
 
-	return [
-		{
-			field_id => "type"
-		},
-		{
-			field_id => "department"
-		},
-		{
-			field_id => "ispublished"
-		},
-		{
-			field_id => "publisher"
-		},
-		{
-			field_id => "publication"
-		},
-		{
-			field_id => "date;res=year",
-			# Name the field 'Year' rather than 'Date'
-			field_name => "metafield_fieldopt_min_resolution_year",
-		},
-		# {
-		# 	field_id => "contributors"
+	if ( defined $self->{processor}->{sconf}->{facets} && ref $self->{processor}->{sconf}->{facets} eq "ARRAY" )
+	{
+		return $self->{processor}->{sconf}->{facets};
+	}
 
-		# },
-	];
+	return [ { field_id => 'datestamp;res=year' } ];
 }
 
 sub datasets


### PR DESCRIPTION
- pub_lib search config (simple, advanced and staff) have been updated to use original hardcoded config from Screen::Search.
- zero searches uses default config from Screen:Search, which just uses datestamp year.

Without changes zero flavour repos will fall over has they don't have department, publisher, ispublished, publication and date fields by default.